### PR TITLE
Explicitly set defaultLocale instead of relying on I18n.defaultLocale

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -6,9 +6,11 @@
 
   I18n.fallbacks = true;
 
-  I18n.autoDetectLocale = function() {
-    var language, locale, userLocale;
+  I18n.autoDetectLocale = function(_arg) {
+    var defaultLocale, language, locale, userLocale;
+    defaultLocale = _arg.defaultLocale;
     userLocale = navigator.userLanguage || navigator.language;
+    I18n.defaultLocale = defaultLocale;
     if (userLocale in I18n.translations) {
       return I18n.locale = userLocale;
     }

--- a/project_template/app/config/i18n.coffee
+++ b/project_template/app/config/i18n.coffee
@@ -1,6 +1,7 @@
 { I18n } = require('maji')
+Settings = require('./settings')
 
 I18n.translations =
   en: require('./locales/en.yml').en
 
-I18n.autoDetectLocale()
+I18n.autoDetectLocale(defaultLocale: Settings.defaultLocale)

--- a/project_template/app/config/settings.development.json
+++ b/project_template/app/config/settings.development.json
@@ -1,3 +1,4 @@
 {
-  "environment": "development"
+  "environment": "development",
+  "defaultLocale": "en-US"
 }

--- a/project_template/app/config/settings.production.json
+++ b/project_template/app/config/settings.production.json
@@ -1,4 +1,5 @@
 {
   "environment": "production",
+  "defaultLocale": "en-US",
   "bugsnagApiKey" : "<your bugsnag API key here>"
 }

--- a/project_template/app/config/settings.test.json
+++ b/project_template/app/config/settings.test.json
@@ -1,3 +1,4 @@
 {
-  "environment": "test"
+  "environment": "test",
+  "defaultLocale": "en-US"
 }

--- a/src/i18n.coffee
+++ b/src/i18n.coffee
@@ -3,8 +3,9 @@ I18n = require('i18n-js')
 # allows nl-NL to fallback to nl if no nl-NL translation is defined
 I18n.fallbacks = true
 
-I18n.autoDetectLocale = ->
+I18n.autoDetectLocale = ({ defaultLocale }) ->
   userLocale = navigator.userLanguage || navigator.language
+  I18n.defaultLocale = defaultLocale
 
   if userLocale of I18n.translations
     # exact locale is supported, use that


### PR DESCRIPTION
The default locale is now passed to I18n.autoDetectLocale().
