### PR TITLE
Enable Mocha HTML reporter

### DIFF
--- a/project_template/karma.conf.js
+++ b/project_template/karma.conf.js
@@ -14,6 +14,12 @@ module.exports = function(karma) {
       'spec/**/*spec.coffee': [ 'browserify' ]
     },
 
+    client: {
+      mocha: {
+        reporter: 'html' // view on http://localhost:9876/debug.html
+      }
+    },
+
     reporters: ['mocha'],
     browsers: [ 'PhantomJS' ],
 

--- a/project_template/spec/view_spec_helper.coffee
+++ b/project_template/spec/view_spec_helper.coffee
@@ -5,5 +5,18 @@ require('maji/lib/marionette_renderer').setup()
 # expose jquery on window for ease of use in specs
 $ = window.$ = require('jquery')
 
+before ->
+  # create an iframe where specs can append there DOM elements,
+  # so the DOM can be debugged interactively.
+  contextFrame = $('<iframe id="test-context"/>')
+    .css('position', 'fixed')
+    .css('top', '70px').css('right', '10px')
+    .css('width', '40%').css('height', '80%')
+    .css('border', '1px solid #eee')
+  $('#mocha').append(contextFrame)
+  window.DOM = contextFrame.contents().find('body')
+
+  $('#mocha-report').css('max-width', '55%')
+
 beforeEach ->
-  $('body').html('')
+  DOM.html('')

--- a/project_template/spec/views/index_page_spec.coffee
+++ b/project_template/spec/views/index_page_spec.coffee
@@ -6,5 +6,5 @@ describe 'IndexPage', ->
     @view = new IndexPage()
 
   it 'shows a message', ->
-    $('body').append @view.render().el
+    DOM.append @view.render().el
     expect(@view.$el.find('p.welcome').text().trim()).to.eq('Welcome to your Maji app!')


### PR DESCRIPTION
This way we provide a similar experience as [Konacha](https://github.com/jfirebaugh/konacha), where the DOM created by for
example Backbone views can be interactively debugged.

![screen shot 2015-03-24 at 19 52 13](https://cloud.githubusercontent.com/assets/304603/6810149/4335031c-d25f-11e4-8f41-74e840c72039.png)
