### PR TITLE
Use the provided path to `maji new` as is. Fixes #12.

### DIFF
--- a/script/create-project
+++ b/script/create-project
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 APP_PACKAGE=$1
 APP_NAME=$(echo $1 | perl -pe 's/.*\.//')
-
-[[ "$2" != */ ]] && APP_DIR="$2/" || APP_DIR="$2"
-APP_PATH=$APP_DIR$APP_NAME
+APP_PATH="$2"
 
 TMP_DIR=$(mktemp -d -t maji)
 


### PR DESCRIPTION
This means:
- `maji new com.example.app example-app` creates a new directory
  `example-app` in the current directory, containing the app.
- `maji new com.example.app .` creates a new app in the current directory
- `maji new com.example.app /path/to/my-app` creates a new app in the
- supplied directory `/path/to/my-app`, and will create the directory if
- it does not exist.
