### PR TITLE
Help is triggered when options are passed before commands on the CLI

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -53,7 +53,7 @@
 
   program.parse(process.argv);
 
-  if (!program.args.length) {
+  if (!process.argv.slice(2).length) {
     program.help();
   }
 

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -47,4 +47,4 @@ program.on '--help', ->
   process.exit(1)
 
 program.parse(process.argv)
-program.help() unless program.args.length
+program.help() unless process.argv.slice(2).length


### PR DESCRIPTION
**What I did**
`bin/maji run -e android`

**What I expected**
The android emulator to start with my maji app

**What I got**
The following text

```
Usage: maji [options] [command]


  Commands:

    run [options] <platform>    build and run a native app for the specified platform
    build [options] <platform>  build a native app for the specified platform
    new <package_name> <path>   create a new Maji app

  Options:

    -h, --help     output usage information
    -V, --version  output the version number
```

**What does work**
`bin/maji run android -e'
