### PR TITLE
Add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Before you can use Maji, make sure you have the following:
 * [Apache Ant](http://ant.apache.org) is used for building Java Applications
 * [PhantomJS](http://phantomjs.org/download.html) is a headless WebKit Browser, scriptable with a JavaScript API
 
+### Windows
+
+Windows support is still under development
+
 ## Getting started
 
 To create a new app execute the following commands in your shell:


### PR DESCRIPTION
See the original PR here: https://github.com/kabisaict/maji/pull/8 which was merged & closed by accident.

To do, document:
- [ ] TDD'ing with Cucumber and Mocha
- [ ] I18n
- [ ] Haml coffee templates
- [ ] Working with Cordova
- [ ] Bugsnag error tracking
- [ ] Per environment settings
- [ ] Make build system
- [ ] Browserify module system
- [ ] CSS autoprefixer
- [x] Iconfont builder
- [ ] Maji CLI
- [x] FAQ
- [x] License
- [ ] Semantic Versioning
- [ ] How to upgrade to a newer version of Maji
