### PR TITLE
Update version of Watchify for new projects

### DIFF
--- a/project_template/package.json
+++ b/project_template/package.json
@@ -41,7 +41,7 @@
     "tiny-lr": "^0.1.5",
     "uglifyify": "^3.0.1",
     "vinyl-fs": "^0.3.13",
-    "watchify": "^2.3.0",
+    "watchify": "^2.6.0",
     "yamlify": "^0.1.2"
   }
 }


### PR DESCRIPTION
The 2.3.x watchify has an issue that it doesn't reload when there is a
JavaScript syntax error. A later version of watchify fixes this.

This fixes #30 
