### PR TITLE
Maintain navigation stack with transitions disabled

### DIFF
--- a/lib/animatable_region.js
+++ b/lib/animatable_region.js
@@ -37,13 +37,14 @@
     };
 
     AnimatableRegion.prototype.goBack = function(route, options) {
+      var _ref;
       if (options == null) {
         options = {};
       }
       this.back = true;
       this.navigationOptions = options;
       if (route == null) {
-        route = this.navigationStack.get(this.navigationStack.length() - 2).route;
+        route = (_ref = this.navigationStack.get(this.navigationStack.length() - 2)) != null ? _ref.route : void 0;
       }
       if (route == null) {
         route = '';
@@ -72,9 +73,6 @@
 
     AnimatableRegion.prototype.open = function(view) {
       var currentFragment, newPage, previousNavigationItem, _ref, _ref1;
-      if (!this.showTransitions) {
-        return AnimatableRegion.__super__.open.call(this, view);
-      }
       currentFragment = Backbone.history.getFragment();
       previousNavigationItem = this.navigationStack.unwind(currentFragment);
       if (this.back) {
@@ -105,7 +103,7 @@
       }
       this._log('stack:', this.navigationStack.toString());
       this.navigationOptions = null;
-      if (this.transition === false) {
+      if (!this.showTransitions || !this.transition) {
         return AnimatableRegion.__super__.open.call(this, view);
       }
       newPage = view;

--- a/src/animatable_region.coffee
+++ b/src/animatable_region.coffee
@@ -22,7 +22,7 @@ class AnimatableRegion extends Marionette.Region
     @back = true
     @navigationOptions = options
 
-    route ?= @navigationStack.get(@navigationStack.length() - 2).route
+    route ?= @navigationStack.get(@navigationStack.length() - 2)?.route
     route ?= ''
 
     window.location.hash = route
@@ -43,8 +43,6 @@ class AnimatableRegion extends Marionette.Region
   # Marionette provides this hook to open a view. It is recommended to implement
   # transitions etc at this point.
   open: (view) ->
-    return super(view) unless @showTransitions
-
     currentFragment = Backbone.history.getFragment()
 
     # Try to unwind the navigation stack until the current route.
@@ -80,7 +78,7 @@ class AnimatableRegion extends Marionette.Region
     # reset all navigation options
     @navigationOptions = null
 
-    if @transition == false
+    if ! @showTransitions || ! @transition
       return super(view)
 
     newPage = view


### PR DESCRIPTION
This way even with transitions disabled you can make the app go back
using AnimatableRegion#goBack.

This mostly revealed during rpsec integration tests where transitions
are usually turned off.

/cc @stefanvr this should fix the issue you were having in rspec. Please let me know if this fixes it for you.