### PR TITLE
Prevent double runs with Karma

### DIFF
--- a/project_template/karma.conf.js
+++ b/project_template/karma.conf.js
@@ -6,7 +6,8 @@ module.exports = function(karma) {
     frameworks: [ 'mocha', 'sinon-chai', 'browserify' ],
 
     files: [
-      'spec/spec_helper.coffee', 'spec/**/*spec.coffee'
+      { pattern: 'spec/spec_helper.coffee', watched: false, included: true, served: true },
+      { pattern: 'spec/**/*spec.coffee', watched: false, included: true, served: true }
     ],
 
     preprocessors: {
@@ -27,7 +28,6 @@ module.exports = function(karma) {
     // browserify configuration
     browserify: {
       debug: true,
-      bundleDelay: 1000, // to prevent double runs when watching, see https://github.com/nikku/karma-browserify/issues/67
       extensions: ['.hamlc', '.coffee'],
       transform: [ 'coffeeify', 'aliasify', 'yamlify', 'haml-coffee-browserify', ['envify', { _: 'purge' }], 'brfs' ]
     }


### PR DESCRIPTION
When running Karma with autoWatch=true often times specs would be run twice after a change to a file. This PR fixes that.

See last comments in https://github.com/nikku/karma-browserify/issues/67 for more details.