### PR TITLE
Add backbone, marionette, jquery and underscore as explicit devDependicies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   },
   "devDependencies": {
     "coffee-script": "1.9.0",
+    "backbone": "~1.1.2",
+    "backbone.marionette": "~1.8.1",
+    "backbone.wreqr": "~1.3.1",
+    "jquery": ">=2.1.3",
+    "underscore": ">=1.6.0",
     "karma": "^0.12.31",
     "karma-mocha": "^0.1.10",
     "karma-mocha-reporter": "^0.3.1",


### PR DESCRIPTION
In npm 3 peerDependencies will no longer automatically be installed.

More recent npm 2 versions already warn about this:

```
npm WARN peerDependencies The peer dependency backbone included from
maji will no
npm WARN peerDependencies longer be automatically installed to fulfill
the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to
depend on it explicitly.
```