### PR TITLE
bug-fix: maji page use target element for goBack

### DIFF
--- a/project_template/app/views/application_page.coffee
+++ b/project_template/app/views/application_page.coffee
@@ -11,7 +11,7 @@ class ApplicationPage extends Maji.Page
 
   goBack: (e) ->
     e && e.preventDefault()
-    bus.execute('go-back', this.$('a[data-rel=back]').attr('href'))
+    bus.execute('go-back', e.target.getAttribute('href'))
 
   onBackButton: (e) ->
     bus.execute('go-back') unless @shouldIgnoreBackButton()


### PR DESCRIPTION
in the edge case that multiple elements are define with a 'go-back' transition the href of the first element was pickedup.

By using the target element this issue is fixed. 