### PR TITLE
Ensure the local npm installed coffee binary is used to compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-export SHELL   := $(shell echo $$SHELL)
-export PATH    := $(PATH):$(shell npm bin)
+export PATH    := $(shell npm bin):$(PATH)
 
 build:
 	coffee --output lib --compile src


### PR DESCRIPTION
Previously, unintentionally the Makefile used to compile Maji would prefer a `coffee` bin in the path if any. This PR fixes that such that the locally installed `coffee` binary is always used.