### PR TITLE
Reduce memory usage by immediately freeing previous page after transition

### DIFF
--- a/src/animatable_region.coffee
+++ b/src/animatable_region.coffee
@@ -112,6 +112,7 @@ class AnimatableRegion extends Marionette.Region
           if @currentPage
             if @currentPage.close then @currentPage.close()
             else @currentPage.remove()
+            @currentPage = null
 
           @back = undefined
 


### PR DESCRIPTION
Free @currentPage reference in AnimatableRegion after page transition

This way the previous page and anything it references can be garbage
collected immediately when the page is out of the viewport.

Thanks @stefanvr for pointing out that previous pages were retained longer than necessary!