### PR TITLE
Feature go-home action

### DIFF
--- a/lib/animatable_region.js
+++ b/lib/animatable_region.js
@@ -36,7 +36,18 @@
       return Backbone.history.navigate(route, options);
     };
 
-    AnimatableRegion.prototype.canGoBack = function() {};
+    AnimatableRegion.prototype.canGoBack = function() {
+      return this.navigationStack.length() > 1;
+    };
+
+    AnimatableRegion.prototype.goHome = function(route, transition) {
+      this.navigationStack.clear();
+      this.navigationStack.push({
+        route: route,
+        transition: transition
+      });
+      return this.goBack(route);
+    };
 
     AnimatableRegion.prototype.goBack = function(route, options) {
       var ref;
@@ -72,10 +83,6 @@
         options.preventClose = true;
       }
       return AnimatableRegion.__super__.show.call(this, view, options);
-    };
-
-    AnimatableRegion.prototype.canGoBack = function() {
-      return this.navigationStack.length() > 1;
     };
 
     AnimatableRegion.prototype.open = function(view) {
@@ -136,6 +143,7 @@
                 } else {
                   _this.currentPage.remove();
                 }
+                _this.currentPage = null;
               }
               _this.back = void 0;
               _this.$el.removeClass('viewport-transitioning');

--- a/lib/page.js
+++ b/lib/page.js
@@ -21,6 +21,14 @@
       return this._parent.canGoBack();
     };
 
+    Page.prototype.transitionBack = function(route, options) {
+      return this._parent.goBack(route, options);
+    };
+
+    Page.prototype.transitionHome = function(route, transition) {
+      return this._parent.goHome(route, transition);
+    };
+
     return Page;
 
   })(Marionette.Layout);

--- a/project_template/app/views/application_page.coffee
+++ b/project_template/app/views/application_page.coffee
@@ -3,18 +3,23 @@ bus  = require('../app').bus
 
 class ApplicationPage extends Maji.Page
   events:
+    'click [data-rel=home]': 'goHome'
     'click [data-rel=back]': 'goBack'
 
   constructor: ->
     super
     @listenTo bus.vent, 'app:backbutton', @onBackButton
 
+  goHome: (e) ->
+    e && e.preventDefault()
+    @transitionHome(e.target.getAttribute('href'), 'slide')
+
   goBack: (e) ->
     e && e.preventDefault()
-    bus.execute('go-back', this.$('a[data-rel=back]').attr('href'))
+    @transitionBack(this.$('a[data-rel=back]').attr('href'))
 
   onBackButton: (e) ->
-    bus.execute('go-back') unless @shouldIgnoreBackButton()
+    @transitionBack() unless @shouldIgnoreBackButton()
 
   shouldIgnoreBackButton: ->
     # implement your logic here when to ignore the back button,

--- a/src/animatable_region.coffee
+++ b/src/animatable_region.coffee
@@ -21,6 +21,11 @@ class AnimatableRegion extends Marionette.Region
   canGoBack: ->
     @navigationStack.length() > 1
 
+  goHome: (route, transition) ->
+    @navigationStack.clear()
+    @navigationStack.unshift { route: route, transition: transition }
+    @goBack(route)
+
   goBack: (route, options = {}) ->
     @back = true
     @navigationOptions = options

--- a/src/navigation_stack.coffee
+++ b/src/navigation_stack.coffee
@@ -5,6 +5,9 @@ class NavigationStack
     @stack = []
     @_prevRoute = null
 
+  unshift: (navigationElement) ->
+    @stack.unshift navigationElement
+
   push: (navigationElement) ->
     @stack.push navigationElement
 

--- a/src/page.coffee
+++ b/src/page.coffee
@@ -7,4 +7,10 @@ class Page extends Marionette.Layout
   canGoBack: ->
     @_parent.canGoBack()
 
+  transitionBack: (route, options) ->
+    @_parent.goBack(route, options)
+
+  transitionHome: (route, transition) ->
+    @_parent.goHome(route, transition)
+
 module.exports = Page


### PR DESCRIPTION
This feature is useful for application that can start on different page then the home page.

In such case the navigation stack cause a "back" animation on forward transitions. With using the goHome action the navigation is always animated as back and the history stack is cleared to ensure correct transition behaviour in the future.