### PR TITLE
Add debug param to generate sourcemaps for JS

### DIFF
--- a/project_template/Makefile
+++ b/project_template/Makefile
@@ -51,7 +51,7 @@ serve: check-server-port clean build-statics build-icons build-css livereload
 	onchange 'public/**/*' -- make build-statics &
 	CSS_OUTPUT_STYLE=expanded onchange 'app/styles/**/*.scss' -- make build-css &
 	onchange 'app/styles/icons/*.svg' -- make build-icons &
-	watchify -v $(BROWSERIFY_BASE_CONFIG) -x bugsnag-js \
+	watchify -d -v $(BROWSERIFY_BASE_CONFIG) -x bugsnag-js \
 	 app/application.coffee -o $(DIST_DIR)/assets/app.js &
 	sleep 2 && http-server -p $(SERVER_PORT) $(DIST_DIR)
 


### PR DESCRIPTION
This PR adds a `-d` param to the `watch` command in `project_template/Makefile` that appends sourcemaps to the generated `app.js`.

This simplifies debugging in Chrome DevTools and adds the possibilities to add the local .coffee files as workspace and use [`Map to File File System Resource`](https://developer.chrome.com/devtools/docs/workspaces).