### PR TITLE
Bugfix/marionette prevent destroy

### DIFF
--- a/lib/animatable_region.js
+++ b/lib/animatable_region.js
@@ -80,7 +80,7 @@
       }
       if (this.transition) {
         this.currentPage = this.currentView;
-        options.preventClose = true;
+        options.preventDestroy = true;
       }
       return AnimatableRegion.__super__.show.call(this, view, options);
     };

--- a/project_template/app/modules/home/home_app.coffee
+++ b/project_template/app/modules/home/home_app.coffee
@@ -12,10 +12,10 @@ class HomeApp.Router extends Marionette.AppRouter
 API =
   home: ->
     IndexPage = require('./views/index_page')
-    app.mainRegion.show new IndexPage(), preventDestroy: true
+    app.mainRegion.show new IndexPage()
   detail: ->
     DetailPage = require('./views/detail_page')
-    app.mainRegion.show new DetailPage(), preventDestroy: true
+    app.mainRegion.show new DetailPage()
 
 HomeApp.addInitializer ->
   new HomeApp.Router

--- a/src/marionnette_extensions/animatable_region.coffee
+++ b/src/marionnette_extensions/animatable_region.coffee
@@ -45,7 +45,7 @@ class AnimatableRegion extends Marionette.Region
 
     if @transition
       @currentPage = @currentView
-      options.preventClose = true
+      options.preventDestroy = true
 
     super(view, options)
 


### PR DESCRIPTION
Hi,

We upgraded the kerkdienstgemist.nl app to the latest Maji version, the transitions didn't work properly anymore. This is the fix. It was some kind of fixed in the template project. But this way its functioning as it did before. 