### PR TITLE
Remove Maji plugin management in favor of Cordova plugin management

### DIFF
--- a/docs/upgrade_guide.md
+++ b/docs/upgrade_guide.md
@@ -118,8 +118,16 @@ The best way to start is to checkout the updated example app.
    * Update use of *Regions*. `@myRegion.show new MySubView` is now `@showChildView('myRegion', new MySubView)`
    * `getChildView: ->` is now `childView: ->`
 
-With these steps your app should become functional again, depending on how much custom stuff your app uses (like overwriting private implementations of Marionette).
 
+5. Maji 2.x uses Cordova plugin management
+
+This means that the Cordova plugins you wish to use should now be defined in `cordova/config.xml`, instead of `cordova/plugins.txt`.
+
+Refer to the Cordova documentation for details: https://cordova.apache.org/docs/en/latest/platform_plugin_versioning_ref/
+
+
+
+With these steps your app should become functional again, depending on how much custom stuff your app uses (like overwriting private implementations of Marionette).
 5. Update all uses of the `Maji.bus` to Backbone.Radio ([see documentation of radio here][backbone-radio])
 
 [marionette-upgrade]: http://marionettejs.com/docs/v3.1.0/upgrade.html

--- a/project_template/cordova/config.xml
+++ b/project_template/cordova/config.xml
@@ -22,4 +22,7 @@
 
     <!-- disable icloud storage sync -->
     <preference name="BackupWebStorage" value="local"/>
+
+    <plugin name="cordova-plugin-splashscreen" spec="~4.0.0"/>
+    <plugin name="com.mallzee.plugin.networkactivity" spec="https://github.com/mallzee/network-activity.git#0904b83c3109560bad8e7dd9be1320bb9303899d"/>
 </widget>

--- a/project_template/cordova/plugins.txt
+++ b/project_template/cordova/plugins.txt
@@ -1,3 +1,0 @@
-# Add your plugins here, one per line
-org.apache.cordova.splashscreen
-com.mallzee.plugin.networkactivity https://github.com/mallzee/network-activity.git#0904b83c3109560bad8e7dd9be1320bb9303899d

--- a/script/_functions
+++ b/script/_functions
@@ -17,7 +17,8 @@ function brew_available() {
 }
 
 function warning() {
-  echo "$(tput setaf 3)$@$(tput sgr0)"
+  [[ $# -eq 0 ]] && local message=$(cat -) || local message="$@"
+  echo "$(tput setaf 3)$message$(tput sgr0)"
 }
 
 function npm_package_available() {

--- a/script/prepare-cordova-platform
+++ b/script/prepare-cordova-platform
@@ -6,22 +6,17 @@ pushd cordova >/dev/null 2>&1
   platform_installed $PLATFORM || cordova platforms add $PLATFORM
   cordova prepare $PLATFORM
 
-  # install cordova plugins
   if [ -f plugins.txt ]; then
-    while read PLUGIN_LINE; do
-      [[ "$PLUGIN_LINE" == \#* ]] && continue
+    warning <<EOF
+cordova/plugins.txt file detected.
 
-      # lines either have just a plugin id, like org.apache.cordova.device in which
-      # they will be fetched from the cordova plugin registry.
-      # lines can also contain both a plugin id _and_ a git url, in which case they'll
-      # be fetched with git. In that case we do still need the plugin id, because that's
-      # what we need to check if the plugin is already installed.
-      IFS=' ' read -a PLUGIN_INFO <<< "$PLUGIN_LINE"
+Maji plugin management is removed.
+Please use Cordova plugin management by configuring your plugins in cordova/config.xml,
+and remove cordova/plugins.txt.
 
-      PLUGIN_ID=${PLUGIN_INFO[0]}
-      PLUGIN_FETCH_TARGET=${PLUGIN_INFO[1]:-${PLUGIN_INFO[0]}}
-
-      cordova plugins | grep -w $PLUGIN_ID >/dev/null 2>&1 || cordova plugins add $PLUGIN_FETCH_TARGET
-    done < plugins.txt
+Refer to the Cordova documentation for details:
+https://cordova.apache.org/docs/en/latest/platform_plugin_versioning_ref/
+EOF
+    exit 1
   fi
 popd >/dev/null 2>&1


### PR DESCRIPTION
This is a breaking change and therefor targets the `2-0-stable` branch.