### PR TITLE
Don't `npm dedupe` on build

### DIFF
--- a/project_template/package.json
+++ b/project_template/package.json
@@ -2,9 +2,6 @@
   "name": "##APP_NAME##",
   "version": "1.0.0",
   "private": true,
-  "scripts": {
-    "postinstall": "npm dedupe --loglevel=error"
-  },
   "dependencies": {
     "backbone": "1.3.3",
     "backbone.localstorage": "~1.1.16",


### PR DESCRIPTION
`npm dedupe` in general is not really needed anymore with npm 3 as the dependency,
tree is already mostly flat, and deduped by default.
This also removes many warnings during build for dependencies that could
not be deduped.