### PR TITLE
Use phantomjs retrieved from NPM. Fixes #92

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Before you can use Maji, make sure you have the following:
 ### Linux
 
 * [Nodejs](http://nodejs.org) allows JavaScript to be run Server-side
-* [Apache Ant](http://ant.apache.org) is used for building Java Applications
-* [PhantomJS](http://phantomjs.org/download.html) is a headless WebKit Browser, scriptable with a JavaScript API
+* [Apache Ant](http://ant.apache.org) is used for building Android Applications
 
 ## Getting started
 
@@ -69,7 +68,7 @@ To start your app, `cd` into its directory, execute `make watch` and navigate to
 ### Running tests
 
 To run test, you have several options:
-* To run JavaScript tests run `bin/karma start`. This will start a Karma server with Phantomjs and will continuously watch your Javascript files and run tests on changes.
+* To run JavaScript tests run `bin/karma start`. This will start a Karma server with Phantomjs headless browser and will continuously watch your Javascript files and run tests on changes.
 * To run JavaScript tests once, run `bin/karma start --single-run`.
 * To run features specs once, run `bundle exec rspec`.
 * To run all tests once, run `bin/ci`.

--- a/dockerfiles/ci/Dockerfile
+++ b/dockerfiles/ci/Dockerfile
@@ -17,12 +17,6 @@ RUN apt-get update \
 RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - \
     && apt-get install --yes nodejs
 
-# Install PhantomJS 2.1.1
-RUN cd /tmp && curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -o phantomjs-2.1.1-linux-x86_64.tar.bz2 \
-    && tar xjf phantomjs-2.1.1-linux-x86_64.tar.bz2 \
-    && mv /tmp/phantomjs-*/bin/phantomjs /usr/bin/ \
-    && rm -r /tmp/phantomjs*
-
 ENV CONTAINER_INIT /usr/local/bin/init-container
 RUN echo '#!/usr/bin/env bash' > $CONTAINER_INIT ; chmod +x $CONTAINER_INIT
 
@@ -37,5 +31,4 @@ RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
-ENV PHANTOMJS_BIN /usr/bin/phantomjs
 ENV BUNDLE_PATH /cache/bundle

--- a/project_template/bin/setup
+++ b/project_template/bin/setup
@@ -7,10 +7,6 @@ if brew_available ; then
   brew_dep_installed 'node' || brew install node
   brew_dep_installed 'ant' || brew install ant
 
-  if ! command_available 'phantomjs' ; then
-    brew install phantomjs
-  fi
-
   # npm is included with node in newer version, so this normally shouldn't be needed.
   command_available 'npm' || brew install npm
 else

--- a/project_template/dockerfiles/ci/Dockerfile
+++ b/project_template/dockerfiles/ci/Dockerfile
@@ -17,12 +17,6 @@ RUN apt-get update \
 RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - \
     && apt-get install --yes nodejs
 
-# Install PhantomJS 2.1.1
-RUN cd /tmp && curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -o phantomjs-2.1.1-linux-x86_64.tar.bz2 \
-    && tar xjf phantomjs-2.1.1-linux-x86_64.tar.bz2 \
-    && mv /tmp/phantomjs-*/bin/phantomjs /usr/bin/ \
-    && rm -r /tmp/phantomjs*
-
 ENV CONTAINER_INIT /usr/local/bin/init-container
 RUN echo '#!/usr/bin/env bash' > $CONTAINER_INIT ; chmod +x $CONTAINER_INIT
 
@@ -37,5 +31,4 @@ RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
-ENV PHANTOMJS_BIN /usr/bin/phantomjs
 ENV BUNDLE_PATH /cache/bundle

--- a/project_template/spec/spec_helper.rb
+++ b/project_template/spec/spec_helper.rb
@@ -11,7 +11,10 @@ RSpec.configure do |config|
 end
 
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, {extensions: ['spec/support/function_bind_polyfill.js']})
+  Capybara::Poltergeist::Driver.new(app, {
+    extensions: ['spec/support/function_bind_polyfill.js'],
+    phantomjs: File.expand_path('node_modules/phantomjs-prebuilt/bin/phantomjs')
+  })
 end
 
 Capybara.default_driver = :poltergeist


### PR DESCRIPTION
We already installed phantomjs via NPM, as well as via Homebrew if that
was available.
Karma would already use the phantomjs binary provided by NPM whereas
Poltergeist would use the one in $PATH.

This commit cleans up that mess and ensures that only a single phantomjs
binary is installed, regardless of platform (one less dependency on
Homebrew) :-)