### PR TITLE
Remove dependency installation via homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,8 @@ Before you can use Maji, make sure you have the following:
 
 ### General
 
-* Ruby, for the Cucumber specs
-* NodeJS, for the build system (`bin/setup` will install this if you've got Homebrew)
-* Homebrew (`bin/setup` will use this to hook you up with all of the dependencies, except Ruby)
-
-### Mac OS X
-
-* [Homebrew](http://brew.sh) a Mac OS X package manager
-
-### Linux
-
-* [Nodejs](http://nodejs.org) allows JavaScript to be run Server-side
-* [Apache Ant](http://ant.apache.org) is used for building Android Applications
+* Ruby + Bundler, for the integration specs
+* NodeJS + NPM, for the build system
 
 ## Getting started
 

--- a/project_template/README.md
+++ b/project_template/README.md
@@ -27,9 +27,8 @@
 
 ### General
 
-* Ruby, for the Cucumber specs
-* NodeJS, for the build system (`bin/setup` will install this if you've got Homebrew)
-* Homebrew (`bin/setup` will use this to hook you up with all of the dependencies, except Ruby)
+* Ruby + Bundler, for the integration specs
+* NodeJS + NPM, for the build system
 
 ### iOS
 
@@ -41,5 +40,4 @@
 * Android SDK
 * Android platform tools installed
 * Android platform 10+.
-* Ant (`brew install ant`)
 * `android` and `adb` in your $PATH (add `path/to/android-sdk-macosx/tools` and `path/to/android-sdk-macosx/platform-tools` to your $PATH).

--- a/project_template/bin/_functions
+++ b/project_template/bin/_functions
@@ -12,16 +12,8 @@ function _md5() {
   return 0
 }
 
-function brew_dep_installed() {
-  brew list | grep "^$@$" >/dev/null 2>&1
-}
-
 function command_available() {
   command -v "$@" >/dev/null 2>&1
-}
-
-function brew_available() {
-  command_available 'brew'
 }
 
 function warning() {

--- a/project_template/bin/setup
+++ b/project_template/bin/setup
@@ -3,16 +3,6 @@ source "$(dirname ${BASH_SOURCE[0]})/_functions"
 PROJECT=$(basename $(pwd))
 echo "Setting up $PROJECT"
 
-if brew_available ; then
-  brew_dep_installed 'node' || brew install node
-  brew_dep_installed 'ant' || brew install ant
-
-  # npm is included with node in newer version, so this normally shouldn't be needed.
-  command_available 'npm' || brew install npm
-else
-  warning 'Warning: Homebrew not detected. Not installing some dependencies.'
-fi
-
 if [[ "$OSTYPE" == "darwin"* ]]; then
   npm_package_available 'ios-deploy@1.8.5' || npm install 'ios-deploy@1.9.0'
   npm_package_available 'ios-sim@5.0.6' || npm install 'ios-sim@5.0.12'

--- a/script/_functions
+++ b/script/_functions
@@ -4,16 +4,8 @@ function platform_installed() {
   cordova platforms | head -n 1 | grep $1 >/dev/null
 }
 
-function brew_dep_installed() {
-  brew list | grep "^$@$" >/dev/null 2>&1
-}
-
 function command_available() {
   command -v "$@" >/dev/null 2>&1
-}
-
-function brew_available() {
-  command_available 'brew'
 }
 
 function warning() {


### PR DESCRIPTION
These dependencies are all documented in the README and should be
installed by the user manually.

Homebrew is just *a* package manager, we shouldn't depend on it.
This also leaves the freedom for people to install dependencies via
other means, even if they have brew installed.