### PR TITLE
Fix flicker in page transitions after upgrade to Marionette 3

### DIFF
--- a/lib/marionette_extensions/animatable_region.js
+++ b/lib/marionette_extensions/animatable_region.js
@@ -24,6 +24,7 @@
       });
       this.showTransitions = opts.showTransitions;
       this.navigationStack = new NavigationStack();
+      this.transitioning = false;
       AnimatableRegion.__super__.constructor.apply(this, arguments);
     }
 
@@ -65,6 +66,12 @@
       return window.location.hash = route;
     };
 
+    AnimatableRegion.prototype._empty = function(view, shouldDestroy) {
+      if (!this.transitioning) {
+        return AnimatableRegion.__super__._empty.apply(this, arguments);
+      }
+    };
+
     AnimatableRegion.prototype.show = function(view, options) {
       var ref;
       if (options == null) {
@@ -78,9 +85,9 @@
       if (this.transition == null) {
         this.transition = view.transition || options.transition;
       }
+      this.transitioning = true;
       if (this.transition) {
         this.currentPage = this.currentView;
-        options.preventDestroy = true;
       }
       return AnimatableRegion.__super__.show.call(this, view, options);
     };
@@ -146,6 +153,7 @@
                 _this.currentPage = null;
               }
               _this.back = void 0;
+              _this.transitioning = false;
               _this.$el.removeClass('viewport-transitioning');
               _this.$el.removeClass("viewport-" + _this.transition);
               return newPage.trigger('transitioned');
@@ -155,6 +163,7 @@
       } else {
         newPage.$el.removeClass('page-pre-in');
         this.back = void 0;
+        this.transitioning = false;
         return newPage.trigger('transitioned');
       }
     };


### PR DESCRIPTION
After upgrade to Marionette 3 the page transitions starting flickering:

![broken](https://cloud.githubusercontent.com/assets/304603/21040309/633fb748-bde4-11e6-8472-84a8f218d28f.gif)

This PR fixes that such that looks like this again:

![fixed](https://cloud.githubusercontent.com/assets/304603/21040319/75119a04-bde4-11e6-893e-f9c3d6b30945.gif)

Reason it broke was that AnimatableRegion overrides some methods in Region, which changed and now caused the old page div to be destroyed before the new page even started transitioning.