### PR TITLE
Defer installing ios-sim and ios-deploy until ios platform is added

### DIFF
--- a/cordova/hooks/before_platform_add.js
+++ b/cordova/hooks/before_platform_add.js
@@ -1,0 +1,30 @@
+function ensureDependencyInstalled(Q, mod) {
+  try {
+    require(`${mod}/package.json`);
+    return Q();
+  } catch(e) {
+    console.log(`Installing ${mod}`);
+    const deferred = Q.defer();
+
+    exec(`npm install ${mod}`, function(exitCode, stdout, stderr) {
+      if(exitCode == 0)
+        deferred.resolve();
+      else
+        deferred.reject();
+    });
+
+    return deferred.promise;
+  }
+}
+
+module.exports = function(context) {
+  if(context.opts.cordova.platforms.includes('ios')) {
+    context.requireCordovaModule('shelljs/global');
+
+    var Q = context.requireCordovaModule('q');
+    return Q.all([
+      ensureDependencyInstalled(Q, 'ios-sim'),
+      ensureDependencyInstalled(Q, 'ios-deploy')
+    ]);
+  }
+}

--- a/project_template/bin/_functions
+++ b/project_template/bin/_functions
@@ -19,8 +19,3 @@ function command_available() {
 function warning() {
   echo "$(tput setaf 3)$@$(tput sgr0)"
 }
-
-function npm_package_available() {
-  local package=$(npm list --depth=0 2>/dev/null | grep "$@" | cut -d ' ' -f2)
-  [[ $package == "$@" ]]
-}

--- a/project_template/bin/setup
+++ b/project_template/bin/setup
@@ -3,11 +3,6 @@ source "$(dirname ${BASH_SOURCE[0]})/_functions"
 PROJECT=$(basename $(pwd))
 echo "Setting up $PROJECT"
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  npm_package_available 'ios-deploy@1.9.0' || npm install 'ios-deploy@1.9.0'
-  npm_package_available 'ios-sim@5.0.12' || npm install 'ios-sim@5.0.12'
-fi
-
 npm install
 bundle install
 

--- a/project_template/cordova/config.xml
+++ b/project_template/cordova/config.xml
@@ -5,6 +5,8 @@
     <content src="index.html" />
     <access origin="*" />
 
+    <hook type="before_platform_add" src="../node_modules/maji/cordova/hooks/before_platform_add.js" />
+
     <preference name="DisallowOverscroll" value="true"/>
     <preference name="Orientation" value="portrait" />
     <preference name="KeyboardDisplayRequiresUserAction" value="false" />


### PR DESCRIPTION
This ensures that you don't need Xcode/Xcode Command Line Tools unless
you actually want to build for iOS.

The only part that's not great is that Cordova doesn't support loading hooks from NPM packages really, so we need to refer to the hook as `../node_modules/maji/cordova/hooks/before_platform_add.js`. However I don't expect people to move the `cordova/` directory really so shouldn't be a practical issue.