### PR TITLE
Backport Maji dev server to Maji 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "main": "lib/index.js",
   "bin": {
-    "maji": "./lib/cli.js"
+    "maji": "./lib/cli.js",
+    "maji-dev-server": "./src/maji-dev-server.js"
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,10 @@
   },
   "dependencies": {
     "i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc8.tar.gz",
-    "commander": "~2.6.0"
+    "commander": "~2.9.0",
+    "express": "4.14.0",
+    "tiny-lr": "1.0.3",
+    "chokidar": "1.6.1",
+    "connect-livereload": "0.6.0"
   }
 }

--- a/project_template/Gemfile
+++ b/project_template/Gemfile
@@ -5,4 +5,7 @@ group :development, :test do
   gem 'capybara', '~> 2.4.4'
   gem 'poltergeist', '~> 1.6.0'
   gem 'scss_lint', '0.38.0'
+
+  # temporary workaround for https://github.com/sickill/rainbow/issues/44
+  gem 'rainbow', '2.1.0'
 end

--- a/src/maji-dev-server.js
+++ b/src/maji-dev-server.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+var path     = require('path');
+var express  = require('express');
+var tinylr   = require('tiny-lr');
+var chokidar = require('chokidar');
+var program  = require('commander');
+
+var parseBoolean = function(value) {
+  return (value === 'true');
+};
+
+var parsePort = function(value) {
+  return parseInt(value) || null;
+};
+
+program
+  .usage('[options] <path>')
+  .option('-p, --port [port]', 'Port to listen on [9090]', parsePort, 9090)
+  .option('-l, --livereload [flag]', 'Enable livereload [true]', parseBoolean, true)
+  .parse(process.argv);
+
+var port = program.port;
+var livereload = program.livereload;
+var assetPath = program.args[0];
+
+if (! assetPath) {
+  program.outputHelp();
+  process.exit(1);
+}
+
+var server = express();
+var startFileWatcher = function() {
+  var watcher = chokidar.watch(assetPath + '/**/*');
+  watcher.on('ready', function(){
+    console.log('Livereload enabled. Watching for changes in', assetPath);
+
+    watcher.on('all', function(event, path) {
+      tinylr.changed(path)
+    });
+  });
+};
+
+if(livereload) {
+  server
+    .use(tinylr.middleware({ app: server, dashboard: true }))
+    .use(require('connect-livereload')({
+      src: '/livereload.js?snipver=1',
+      include: [ '/', '.*\.html']
+    }));
+}
+
+server
+  .use(express.static(assetPath, {
+    etag: false,
+    lastModified: false
+  }))
+  .listen(port, function() {
+    console.log('Server listening on', port);
+    if(livereload) startFileWatcher();
+  });


### PR DESCRIPTION
It's a non breaking change and is useful to me on Maji 1.x since my current project hasn't upgraded to Maji 2.x yet.

Note that this PR leaves the project template untouched. New projects should use Maji 2.x instead.