### PR TITLE
Switch from Browserify to webpack for new Maji projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated Mocha to 3.1.2
 - Updated jQuery to 3.0.0
 - Node.js >= 6 is now required
+- Switched from Browserify to webpack module bundler
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A Maji Mobile App comes with several frameworks built-in and configured to work 
  * [MarionetteJS](http://marionettejs.com) Marionette simplifies Backbone Views
  * [FastClick](http://ftlabs.github.io/fastclick/) disable the delay between click and the action on iOS
  * [jQuery](http://jquery.com) JavaScript library for working with the DOM
- * [Browserify](http://browserify.org) is a JavaScript module system that supports CommonJS syntax
+ * [Webpack](https://webpack.js.org/) is a JavaScript module bundler
  * [BugSnagJS](https://github.com/bugsnag/bugsnag-js) JavaScript client for [BugSnag](http://bugsnag.com/) exception tracker
  * [Karma](http://karma-runner.github.io/) is a JavaScript test runner
  * [MochaJS](http://mochajs.org) a JavaScript testing framework that supports a BDD style of writing tests

--- a/docs/upgrade_guide.md
+++ b/docs/upgrade_guide.md
@@ -148,7 +148,9 @@ All projects created with Maji 2.0 are configured like this out of the box.
 
 Update all uses of the `Maji.bus` to Backbone.Radio ([see documentation of radio here][backbone-radio])
 
+## Switch from Browserify to webpack (optional)
 
+With Maji 2.x new projects use webpack for module bundling. While not required it's recommended that you migrate your projects to webpack, see [this Pull Request](https://github.com/kabisa/maji/pull/128) for reasoning and benefits. This PR can be used as a basis to migrate your project to webpack.
 
 With these steps your app should become functional again, depending on how much custom stuff your app uses (like overwriting private implementations of Marionette).
 

--- a/project_template/Makefile
+++ b/project_template/Makefile
@@ -2,14 +2,6 @@ export DIST_DIR        ?= ./dist
 export SHELL           := /bin/bash -e -o pipefail
 export PATH            := $(PATH):$(shell npm bin)
 export APP_ENV         ?=development
-BROWSERIFY_BASE_CONFIG = \
-	-t coffeeify \
-	-t aliasify \
-	-t yamlify \
-	-t [ haml-coffee-browserify ] \
-	-t [ envify purge ] \
-	-t brfs \
-	--extension .hamlc --extension .coffee
 
 dist: clean build-statics build-js build-icons build-css revhash
 
@@ -29,8 +21,7 @@ revhash:
 	perl -i -pe s/app.css/app-$$HASH.css/ dist/index.html
 
 build-js:
-	browserify -g uglifyify $(BROWSERIFY_BASE_CONFIG) --debug \
-		app/application.coffee | exorcist $(DIST_DIR)/assets/app.js.map | sed '/^\s*$$/d' > $(DIST_DIR)/assets/app.js
+	webpack --output-path $(DIST_DIR)/assets/
 
 build-css:
 	node-sass --stdout --output-style $${CSS_OUTPUT_STYLE:-compressed} --include-path vendor/styles app/styles/application.scss | postcss --use autoprefixer --autoprefixer.browsers 'ios >= 8, android >= 4, ie >=10' > $(DIST_DIR)/assets/app.css
@@ -43,8 +34,7 @@ serve: clean build-statics build-icons build-css
 	onchange 'public/**/*' -- make build-statics &
 	CSS_OUTPUT_STYLE=expanded onchange 'app/styles/**/*.scss' -- make build-css &
 	onchange 'app/styles/icons/*.svg' -- make build-icons &
-	watchify -d -v $(BROWSERIFY_BASE_CONFIG) -x bugsnag-js \
-	 app/application.coffee -o $(DIST_DIR)/assets/app.js &
+	webpack --output-path $(DIST_DIR)/assets/ --watch &
 	sleep 2 && maji-dev-server $(DIST_DIR) --port=$(SERVER_PORT) --livereload=$(LIVERELOAD)
 
 watch: serve

--- a/project_template/app/application.coffee
+++ b/project_template/app/application.coffee
@@ -1,10 +1,10 @@
 $               = require('jquery')
-attachFastClick = require('fastclick')
+FastClick       = require('fastclick')
 app             = require('./app')
 
 $ ->
   app.start()
-  attachFastClick(document.body)
+  FastClick.attach(document.body)
 
   # Stretch main container height so it's not resized when the viewport is
   # resized. This happens on Android when the keyboard pops up.

--- a/project_template/app/config/settings.coffee
+++ b/project_template/app/config/settings.coffee
@@ -1,5 +1,1 @@
-fs = require('fs')
-
-module.exports = JSON.parse(
-  fs.readFileSync(__dirname + "/settings.#{process.env.APP_ENV}.json", 'utf8')
-)
+module.exports = require("./settings.#{process.env.APP_ENV}.json")

--- a/project_template/karma.conf.js
+++ b/project_template/karma.conf.js
@@ -3,16 +3,14 @@
 module.exports = function(karma) {
   karma.set({
 
-    frameworks: [ 'mocha', 'sinon-chai', 'browserify' ],
+    frameworks: [ 'mocha', 'sinon-chai' ],
 
     files: [
-      { pattern: 'spec/spec_helper.coffee', watched: false, included: true, served: true },
-      { pattern: 'spec/**/*spec.coffee', watched: false, included: true, served: true }
+      'spec/spec_index.coffee'
     ],
 
     preprocessors: {
-      'spec/spec_helper.coffee': [ 'browserify' ],
-      'spec/**/*spec.coffee': [ 'browserify' ]
+      'spec/spec_index.coffee': ['webpack']
     },
 
     client: {
@@ -25,11 +23,9 @@ module.exports = function(karma) {
     reporters: ['mocha'],
     browsers: [ 'PhantomJS' ],
 
-    // browserify configuration
-    browserify: {
-      debug: true,
-      extensions: ['.hamlc', '.coffee'],
-      transform: [ 'coffeeify', 'aliasify', 'yamlify', 'haml-coffee-browserify', ['envify', { _: 'purge' }], 'brfs' ]
+    webpack: require('./webpack.config.js'),
+    webpackMiddleware: {
+      stats: 'errors-only'
     }
   });
 };

--- a/project_template/package.json
+++ b/project_template/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "##APP_NAME##",
+  "name": "example",
   "version": "1.0.0",
   "private": true,
   "dependencies": {
@@ -14,43 +14,32 @@
     "maji": "kabisa/maji#2-0-stable"
   },
   "devDependencies": {
-    "acorn": "~2.6.4",
     "autoprefixer": "~6.3.3",
-    "postcss-cli": "~2.5.1",
-    "brfs": "~1.4.3",
-    "browserify": "~13.0.0",
-    "coffeeify": "~2.0.1",
-    "aliasify": "~1.9.0",
     "chai": "~3.5.0",
+    "coffee-loader": "^0.7.2",
     "coffeelint": "~1.15.0",
     "cordova": "~6.4.0",
-    "envify": "~3.4.0",
-    "exorcist": "~0.4.0",
     "gulp-iconfont": "~6.0.0",
     "gulp-iconfont-css": "~2.0.0",
     "haml-coffee-browserify": "~0.0.4",
-    "sinon": "~1.17.2",
+    "json-loader": "^0.5.4",
     "karma": "~0.13.22",
-    "karma-browserify": "~5.0.2",
     "karma-mocha": "~0.2.2",
     "karma-mocha-reporter": "~2.0.0",
-    "karma-sinon-chai": "~1.2.0",
     "karma-phantomjs-launcher": "~1.0.0",
-    "lolex": "^1.4.0",
+    "karma-sinon-chai": "~1.2.0",
+    "karma-webpack": "^1.8.1",
+    "memo-is": "0.0.2",
     "mocha": "~3.1.2",
     "node-sass": "~3.13.0",
     "onchange": "~2.1.2",
     "phantomjs-prebuilt": "~2.1.3",
+    "postcss-cli": "~2.5.1",
+    "sinon": "~1.17.2",
     "sinon-chai": "2.8.0",
-    "uglifyify": "~3.0.1",
+    "transform-loader": "^0.2.3",
     "vinyl-fs": "~2.4.2",
-    "watchify": "~3.7.0",
-    "yamlify": "~0.1.2",
-    "memo-is": "0.0.2"
-  },
-  "aliasify": {
-    "aliases": {
-      "app": "./app"
-    }
+    "webpack": "^2.2.0-rc.3",
+    "yaml-loader": "^0.4.0"
   }
 }

--- a/project_template/spec/spec_index.coffee
+++ b/project_template/spec/spec_index.coffee
@@ -1,0 +1,14 @@
+# https://github.com/webpack/karma-webpack#alternative-usage
+#
+# Without this, karma and webpack don't play nice together since webpack
+# will compile a bundle with jquery, marionette etc for each spec file.
+#
+# With this, all specs are compiled together. Single specs can be run with
+# mochas describe.only feature.
+testsContext = require.context('.', true, /_spec$/)
+testsContext.keys().forEach (path) ->
+  try
+    testsContext(path)
+  catch err
+    console.error('[ERROR] WITH SPEC FILE:', path)
+    console.error(err)

--- a/project_template/webpack.config.js
+++ b/project_template/webpack.config.js
@@ -1,0 +1,44 @@
+const path          = require('path');
+const webpack       = require('webpack');
+
+const APP_ENV       = process.env.APP_ENV || 'development';
+const IS_PROD_BUILD = ! ["development", "test"].includes(APP_ENV);
+
+const plugins = [
+  new webpack.DefinePlugin({
+    'process.env':{
+      'APP_ENV': JSON.stringify(APP_ENV),
+    }
+  })
+];
+
+if(IS_PROD_BUILD) plugins.push(new webpack.optimize.UglifyJsPlugin({minimize: true}));
+
+module.exports = {
+  entry: './app/application.coffee',
+  output: {
+    path: path.resolve(__dirname, 'dist/assets'),
+    filename: 'app.js'
+  },
+  module: {
+    rules: [
+      { test: /\.coffee$/, loader: 'coffee-loader' },
+      { test: /\.hamlc$/, loader: 'transform-loader?haml-coffee-browserify' },
+      { test: /\.json$/, loader: 'json-loader' },
+      { test: /\.yml$/, loader: 'json-loader!yaml-loader' },
+    ]
+  },
+  resolve: {
+    extensions: ['.js', '.coffee', '.hamlc'],
+    alias: {
+      'app': path.resolve(__dirname, 'app/')
+    }
+  },
+  node: {
+    process: false
+  },
+  plugins: plugins,
+  performance: {
+    hints: false
+  }
+}


### PR DESCRIPTION
This PR replaces Browserify with [webpack](https://webpack.js.org/) for new Maji projects. There are many reasons for this change; I'll outline the most important ones.

* The webpack community is much more thriving than the Browserify community. Browserify has not seen many significant changes over the last two years and many browserify related projects have stalled too.
  * It's arguable if a slower pace of development is bad or not, but it has certainly shown that Browserify is getting less and less attention in the community, resulting in long standing bugs in community projects like `karma-browserify` etc.
* webpack has [proper documentation](https://webpack.js.org/configuration/), much better than Browserify.
* webpack is easier to configure, especially for more advanced configurations involving for example code splitting.
  * webpack also has much more functionality built in, allowing us to drop a few dev dependencies
  * This PR only uses webpack to build javascript, but in the future we could expand that into building all assets.
* Browserify doesn't really play nice with Babel, this will be more important in the future as a move to ES 2015 is likely. The `babelify` plugin itself works fine, but many Browserify plugins have issues processing ES2015 code.
* webpack is faster. On a medium size codebase compile times improved by 25%.
* webpack allows for more advanced optimizations. It's for example trivial to exclude unused `moment.js` locales.

From a UX point of view nothing will change. Maji projects will continue shipping with a Makefile supporting the same old commands `make dist` and `make watch`. Also existing projects don't _have_ to switch, if for some reason a project wants to stick with Browserify that's fine and completely compatible.