### PR TITLE
Add --cors option to maji-dev-server

### DIFF
--- a/src/maji-dev-server.js
+++ b/src/maji-dev-server.js
@@ -17,10 +17,12 @@ program
   .usage('[options] <path>')
   .option('-p, --port [port]', 'Port to listen on [9090]', parsePort, 9090)
   .option('-l, --livereload [flag]', 'Enable livereload [true]', parseBoolean, true)
+  .option('-c, --cors', 'Enable cors')
   .parse(process.argv);
 
 var port = program.port;
 var livereload = program.livereload;
+var cors = program.cors;
 var assetPath = program.args[0];
 
 if (! assetPath) {
@@ -47,6 +49,14 @@ if(livereload) {
       src: '/livereload.js?snipver=1',
       include: [ '/', '.*\.html']
     }));
+}
+
+if(cors) {
+  server.use(function(req, res, next) {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header('Access-Control-Allow-Headers', req.get('Access-Control-Request-Headers') || '*');
+    next();
+  });
 }
 
 server


### PR DESCRIPTION
Adds simple, wide open cors config. Suitable for development only.