### PR TITLE
Fix bugsnag warnings in development

### DIFF
--- a/project_template/app/config/bugsnag.coffee
+++ b/project_template/app/config/bugsnag.coffee
@@ -1,7 +1,5 @@
 Settings = require('./settings')
 
-try
+if Settings.bugsnagApiKey
   Bugsnag = require('bugsnag-js')
-  Bugsnag.apiKey = Settings.bugsnagApiKey if Settings.bugsnagApiKey
-catch
-  # ignore, bugsnag may not be included
+  Bugsnag.apiKey = Settings.bugsnagApiKey


### PR DESCRIPTION
With browserify bugsnag-js was excluded in development builds. With the
switch to webpack this was no longer the case, unintentionally.

Excluding bugsnag from the development bundle seems a bit overkill,
so instead with this commit we simply don't initialize bugsnag
unless a bugsnag API key is included.