### PR TITLE
Inject livereload.js into head

### DIFF
--- a/src/maji-dev-server.js
+++ b/src/maji-dev-server.js
@@ -47,7 +47,11 @@ if(livereload) {
     .use(tinylr.middleware({ app: server, dashboard: true }))
     .use(require('connect-livereload')({
       src: '/livereload.js?snipver=1',
-      include: [ '/', '.*\.html']
+      include: [ '/', '.*\.html'],
+      rules: [{
+        match: /<\/head>(?![\s\S]*<\/head>)/i,
+        fn: function(w, s) { return s + w; }
+      }]
     }));
 }
 


### PR DESCRIPTION
This is safer than injecting it in the body, as the entire body might be
replaced by client side content. The head is unlikely to be emptied ever
so injecting it there seems reasonable.