### PR TITLE
Set default Cordova SplashScreenDelay to 0

### DIFF
--- a/project_template/cordova/config.xml
+++ b/project_template/cordova/config.xml
@@ -17,9 +17,8 @@
     <!-- allows programmatic focus() calls to trigger the keyboard on iOS -->
     <preference name="KeyboardDisplayRequiresUserAction" value="false" />
 
-    <!-- only for android -->
     <preference name="SplashScreen" value="splash" />
-    <preference name="SplashScreenDelay" value="1500" />
+    <preference name="SplashScreenDelay" value="0" />
 
     <!-- target Android SDK versions //-->
     <preference name="android-minSdkVersion" value="14" />


### PR DESCRIPTION
0 is a more sensible value. Depending on the time it takes to render
your initial screen you might want to increase this value, or hide the
splashscreen from Javascript after you've rendered your initial screen.
No need to always wait 1500 msec.