### PR TITLE
Fix issue where default --env value overrides APP_ENV env var

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -82,7 +82,7 @@
 
   program.command('run <platform>').description('Build and run a native app for the specified platform').option('-e, --emulator', 'run on emulator instead of an actual device').option('--env --environment [environment]', 'APP_ENV to run with [development]').action(function(platform, options) {
     var app_env, deviceTypeArg, env;
-    app_env = options.environment || 'development';
+    app_env = options.environment || process.env.APP_ENV || 'development';
     env = {
       'APP_ENV': app_env
     };
@@ -92,7 +92,7 @@
 
   program.command('build [platform]').description('Build a native app for the specified platform').option('--release', 'create a release build').option('--env --environment [environment]', 'APP_ENV to build with [production]').action(function(platform, options) {
     var app_env, env, releaseArg;
-    app_env = options.environment || 'production';
+    app_env = options.environment || process.env.APP_ENV || 'production';
     env = {
       'APP_ENV': app_env
     };

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -57,7 +57,7 @@ program
   .option('-e, --emulator', 'run on emulator instead of an actual device')
   .option('--env --environment [environment]', 'APP_ENV to run with [development]')
   .action (platform, options) ->
-    app_env = options.environment || 'development'
+    app_env = options.environment || process.env.APP_ENV || 'development'
     env = {
       'APP_ENV': app_env
     }
@@ -71,7 +71,7 @@ program
   .option('--release', 'create a release build')
   .option('--env --environment [environment]', 'APP_ENV to build with [production]')
   .action (platform, options) ->
-    app_env = options.environment || 'production'
+    app_env = options.environment || process.env.APP_ENV || 'production'
     env = {
       'APP_ENV': app_env
     }


### PR DESCRIPTION
During `maji run` `maji build` is invoked, without any arguments. During
this process APP_ENV is set, but no --env is set.

This commit ensures that in that case the environment variable is
respected.