### PR TITLE
Fix issue where quickly triggering transitions leaves DOM dirty

### DIFF
--- a/lib/marionette_extensions/animatable_region.js
+++ b/lib/marionette_extensions/animatable_region.js
@@ -137,21 +137,30 @@
         this.$el.addClass("viewport-transitioning viewport-" + this.transition);
         return setTimeout(((function(_this) {
           return function() {
+            var cleanupNextPage, cleanupPrevPage;
             window.scrollTo(0, 0);
             _this.currentPage.$el.addClass("animated " + _this.transition + " out" + (_this.back ? ' reverse' : ''));
             newPage.$el.removeClass('page-pre-in');
             newPage.$el.addClass("animated " + _this.transition + " in" + (_this.back ? ' reverse' : ''));
-            return setTimeout((function() {
+            cleanupNextPage = function() {
               newPage.$el.removeClass("animated " + _this.transition + " in reverse");
-              newPage.$el.css('z-index', '');
-              if (_this.currentPage) {
-                if (_this.currentPage.destroy) {
-                  _this.currentPage.destroy();
-                } else {
-                  _this.currentPage.remove();
+              return newPage.$el.css('z-index', '');
+            };
+            cleanupPrevPage = (function(prevPage) {
+              return function() {
+                if (prevPage) {
+                  if (prevPage.destroy) {
+                    return prevPage.destroy();
+                  } else {
+                    return prevPage.remove();
+                  }
                 }
-                _this.currentPage = null;
-              }
+              };
+            })(_this.currentPage);
+            return setTimeout((function() {
+              cleanupNextPage();
+              cleanupPrevPage();
+              _this.currentPage = null;
               _this.back = void 0;
               _this.transitioning = false;
               _this.$el.removeClass('viewport-transitioning');

--- a/src/marionette_extensions/animatable_region.coffee
+++ b/src/marionette_extensions/animatable_region.coffee
@@ -116,20 +116,25 @@ class AnimatableRegion extends Marionette.Region
         newPage.$el.removeClass('page-pre-in')
         newPage.$el.addClass("animated #{@transition} in#{if @back then ' reverse' else ''}")
 
+        cleanupNextPage = =>
+          newPage.$el.removeClass("animated #{@transition} in reverse")
+          newPage.$el.css('z-index', '')
+
+        cleanupPrevPage = ((prevPage) -> () ->
+          if prevPage
+            if prevPage.destroy then prevPage.destroy()
+            else prevPage.remove()
+        )(@currentPage)
+
         # newPage.$el.one 'webkitAnimationEnd mozAnimationEnd msAnimationEnd oAnimationEnd animationend', =>
         # FIXME: this is a temporary workaround for animationend events often times not
         # firing on WP8. Transitions in the app all use the same duration so a setTimeout is good
         # enough as a workaround.
         setTimeout((=>
-          newPage.$el.removeClass("animated #{@transition} in reverse")
-          newPage.$el.css('z-index', '')
+          cleanupNextPage()
+          cleanupPrevPage()
 
-          # remove the current page, if any
-          if @currentPage
-            if @currentPage.destroy then @currentPage.destroy()
-            else @currentPage.remove()
-            @currentPage = null
-
+          @currentPage = null
           @back = undefined
           @transitioning = false
 


### PR DESCRIPTION
If a transition was triggered while another transition
was still running (i.e. within its “transition 
duration”), the delayed cleanup function would only 
see the latest value for @currentPage.
Fixed by capturing the value of @currentPage at the
moment the transition is initiated.

---

This would cause artifacts like suddenly being able to horizontally drag the regions, as they were left with markup that's specific to the transition.