### PR TITLE
Update documentation-url in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For our Frequently Asked Questions, see [here](docs/faq.md).
 Here are some links to documentation you might need:
 
  * [Backbone](http://backbonejs.org)
- * [Marionette](http://marionettejs.com/docs/v1.8.7/)
+ * [Marionette](http://marionettejs.com/docs/v3.1.0/)
  * [Mocha](http://mochajs.org/#assertions)
  * [Chai Expect/Should](http://chaijs.com/api/bdd/)
  * [Apache Cordova](http://cordova.apache.org/docs/en/4.0.0/)


### PR DESCRIPTION
package.json in the master branch shows `"backbone.marionette": "3.1.0"`, so it seems the url to Marionette's docs needs to be updated.