### PR TITLE
Fix broken production build due to invalid sentryDsn used as example

### DIFF
--- a/project_template/src/config/sentry.js
+++ b/project_template/src/config/sentry.js
@@ -9,6 +9,13 @@ if (Settings.sentryDsn) {
       revision: __BUILD_IDENTIFIER__
     }
   }).install();
+} else {
+  if (process.env.NODE_ENV === "production") {
+    /* eslint-disable no-console */
+    console.warn(`Sentry exception tracking is NOT enabled. Either add a 'sentryDsn' property
+    in 'settings.production.json' or remove the Sentry import in index.js to silence this warning.`);
+    /* eslint-enable no-console */
+  }
 }
 
 export default Raven;

--- a/project_template/src/config/settings.production.json
+++ b/project_template/src/config/settings.production.json
@@ -1,5 +1,4 @@
 {
   "environment": "production",
-  "defaultLocale": "en-US",
-  "sentryDsn" : "<your sentry.io public DSN here>"
+  "defaultLocale": "en-US"
 }


### PR DESCRIPTION
Sentry will raise when the configured DSN is invalid.
So instead of adding a sample value in the config, we console.warn in
production if no DSN is configured.