### PR TITLE
Add init script to ease setting up new projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,10 @@ Before you can use Maji, make sure you have the following:
 
 ## Getting started
 
-To create a new app execute the following commands in your shell:
+To create a new app execute the following command in your shell:
 
-```
-$ yarn add maji
-$ ./node_modules/.bin/maji new org.example.my-app /desired/path/to/your/project/
-$ cd /desired/path/to/your/project/
-$ bin/setup
+```sh
+bash <(curl -fsSL https://raw.githubusercontent.com/kabisa/maji/master/script/init.sh)
 ```
 
 Your new Maji app will now be generated at the supplied path.

--- a/script/init.sh
+++ b/script/init.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+command -v yarn >/dev/null || (echo "Yarn package manager not found in \$PATH, aborting." && exit 1)
+
+echo -e "Welcome to the Maji installer. This script will help you setup your new Maji project.\n"
+
+while [[ -z "$APP_PACKAGE" ]]
+do
+  read -p "Enter a package name: " APP_PACKAGE
+done
+
+while [[ -z "$APP_PATH" ]]
+do
+  read -p "Enter a directory: " APP_PATH
+done
+
+TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t maji)
+
+pushd "$TMP_DIR" >/dev/null 2>&1
+  yarn add --silent maji --no-lockfile --prod
+  ./node_modules/.bin/maji new "$APP_PACKAGE" "$APP_PATH"
+  RESULT=$?
+popd >/dev/null 2>&1
+
+rm -r $TMP_DIR
+exit $RESULT


### PR DESCRIPTION
Currently to create a new Maji project, the Maji npm module must be installed first and then the Maji CLI must be invoked manually to create a new project. This will also leave an empty directory with a `node_modules/maji` module behind, if not installed globally.

To ease this process this PR adds a 'curlable' init script, that installs the latest published Maji module from NPM in a temp folder and invokes the Maji CLI to create the new project.

With this we can make the process of a new project as simple as `bash <(curl -fsSL https://maji-mobile.com/new-project.sh)`.