### PR TITLE
Fix Maji CLI commands delegating to Yarn

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -10,7 +10,7 @@ const program = require("commander");
 program.version(maji_package.version);
 
 const runYarn = function(args, env_args = {}) {
-  return runCmd("yarn", [...Array.from(args), "--silent"], env_args);
+  return runCmd("yarn", ["--silent", ...Array.from(args)], env_args);
 };
 
 const runCmd = function(cmd, args, env_args = {}) {


### PR DESCRIPTION
In Yarn 0.x this worked fine, but in Yarn 1.x the silent flag must be
passed first.

Fixes #171.