### PR TITLE
Compare components by their url when applying transitions

### DIFF
--- a/project_template/src/support/pageTransitionSupport.js
+++ b/project_template/src/support/pageTransitionSupport.js
@@ -22,26 +22,27 @@ class PageContainer extends Component {
     const nextPage = props.children[0];
     const previousPage = this.state.currentPage;
 
-    if (nextPage.nodeName !== previousPage.nodeName) {
+    if (nextPage.attributes.url !== previousPage.attributes.url) {
       this.setState({ previousPage, currentPage: nextPage });
     }
   }
 
   render() {
+    const { previousPage, currentPage } = this.state;
     const isBack = history.action !== "PUSH";
     const animation =
-      isBack && this.state.previousPage != null
-        ? transitionAnimationForPage(this.state.previousPage)
-        : transitionAnimationForPage(this.state.currentPage);
+      isBack && previousPage != null
+        ? transitionAnimationForPage(previousPage)
+        : transitionAnimationForPage(currentPage);
 
     const currentClassName =
-      this.state.previousPage == null
+      previousPage == null
         ? ""
         : `maji-page-animating maji-page-animation-${animation} maji-page-incoming${isBack
             ? " maji-page-reverse"
             : ""}`;
     const previousClassName =
-      this.state.previousPage == null
+      previousPage == null
         ? ""
         : `maji-page-animating maji-page-animation-${animation} maji-page-outgoing${isBack
             ? " maji-page-reverse"
@@ -49,12 +50,12 @@ class PageContainer extends Component {
 
     return (
       <div class="maji-page-container">
-        <div class={currentClassName}>{this.state.currentPage}</div>
+        <div class={currentClassName}>{currentPage}</div>
         <div
           class={previousClassName}
           onAnimationEnd={() => this.setState({ previousPage: null })}
         >
-          {this.state.previousPage}
+          {previousPage}
         </div>
       </div>
     );
@@ -63,8 +64,8 @@ class PageContainer extends Component {
 
 export const augmentRouter = function(RouterClass) {
   return class TransitionAwareRouter extends RouterClass {
-    render() {
-      return <PageContainer>{super.render(...arguments)}</PageContainer>;
+    render(...args) {
+      return <PageContainer>{super.render(...args)}</PageContainer>;
     }
   };
 };

--- a/project_template/test/spec/support/pageTransitionSupport.spec.js
+++ b/project_template/test/spec/support/pageTransitionSupport.spec.js
@@ -24,7 +24,7 @@ describe("pageTransitionSupport", function() {
     history.action = "PUSH";
     this.startingPage = mount(
       <Router>
-        <PageA />
+        <PageA url="/a" />
       </Router>
     );
   });
@@ -37,7 +37,7 @@ describe("pageTransitionSupport", function() {
     it("wraps incoming and outgoing pages in transition containers", function() {
       const nextPage = mount(
         <Router>
-          <PageB />
+          <PageB url="/b" />
         </Router>,
         this.startingPage
       );
@@ -60,7 +60,7 @@ describe("pageTransitionSupport", function() {
       it("uses that as transition animation instead of default 'slide'", function() {
         const nextPage = mount(
           <Router>
-            <PageB transition="foobar" />
+            <PageB url="/b" transition="foobar" />
           </Router>,
           this.startingPage
         );
@@ -85,33 +85,26 @@ describe("pageTransitionSupport", function() {
     beforeEach(function() {
       this.currentPage = mount(
         <Router>
-          <PageB />
+          <PageB url="/b" />
         </Router>,
         this.startingPage
       );
       history.action = "POP";
     });
 
-    it("plays animation of previous page in reverse", function() {
+    it("plays animations in reverse", function() {
       const nextPage = mount(
         <Router>
-          <PageA />
+          <PageA url="/a" />
         </Router>,
         this.currentPage
       );
 
-      expect(nextPage.outerHTML).to.contain(
-        mount(
-          <div class="maji-page-container">
-            <div class="maji-page-animating maji-page-animation-slide maji-page-incoming maji-page-reverse">
-              <h1>PageA</h1>
-            </div>
-            <div class="maji-page-animating maji-page-animation-slide maji-page-outgoing maji-page-reverse">
-              <h1>PageB</h1>
-            </div>
-          </div>
-        ).outerHTML
+      const pages = nextPage.querySelectorAll(
+        ".maji-page-animating.maji-page-reverse"
       );
+
+      expect(pages.length).to.eql(2);
     });
   });
 });

--- a/project_template/test/spec/support/pageTransitionSupport.spec.js
+++ b/project_template/test/spec/support/pageTransitionSupport.spec.js
@@ -79,6 +79,32 @@ describe("pageTransitionSupport", function() {
         );
       });
     });
+
+    context("given the same URL as previous page", function() {
+      it("prevents the transition", function() {
+        const nextPage = mount(
+          <Router>
+            <PageA url="/a" />
+          </Router>,
+          this.startingPage
+        );
+
+        expect(nextPage.querySelector(".maji-page-animating")).to.be.null;
+      });
+    });
+
+    context("given the same component kind as previous page", function() {
+      it("still performs the transition", function() {
+        const nextPage = mount(
+          <Router>
+            <PageA url="/someOtherUrl" />
+          </Router>,
+          this.startingPage
+        );
+
+        expect(nextPage.querySelector(".maji-page-animating")).not.to.be.null;
+      });
+    });
   });
 
   context("moving back to a previous page", function() {


### PR DESCRIPTION
Routed components will always have a url attribute
applied to them by the router.
Previously we were comparing based on nodeName,
which would prevent transitioning between different
component instances of the same kind.