### PR TITLE
Run ChromeHeadless from karma runner with —no-sandbox

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,13 @@ module.exports = function(karma) {
     },
 
     reporters: ["mocha"],
-    browsers: ["ChromeHeadless"],
+    browsers: ["ChromeHeadlessNoSandbox"],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox"]
+      }
+    },
 
     rollupPreprocessor: require("./rollup.config")
   });

--- a/project_template/config/karma.js
+++ b/project_template/config/karma.js
@@ -34,7 +34,13 @@ module.exports = function(config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ["ChromeHeadless"],
+    browsers: ["ChromeHeadlessNoSandbox"],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox"]
+      }
+    },
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: false,


### PR DESCRIPTION
Same as what already happens with nightwatch.

This fixes running tests in Docker.

Cherry picked commit by @ruisalgado .