### PR TITLE
Let maji build command read NODE_ENV from environment

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -97,7 +97,8 @@ program
     "NODE_ENV to build with [production]"
   )
   .action(function(platform, options) {
-    const node_env = options.environment || "production";
+    const node_env =
+      options.environment || process.env.NODE_ENV || "production";
     const env = {
       NODE_ENV: node_env
     };


### PR DESCRIPTION
The `bin/maji build` command wasn't able to read `NODE_ENV` from the environment, only from the passed in options. Because the build command is called from the `bin/maji run` command, but without passing in options, we should read from the environment.

If you set the environment of the run command by using the options: `bin/maji run --env test`, it will still build production. If you set it via the `NODE_ENV` environment variable it will build the right environment: `NODE_ENV=test bin/maji run`.

Therefore, this is a partial solution to #187.