### PR TITLE
Update Redux DevTools Extension reference

### DIFF
--- a/project_template/src/store.js
+++ b/project_template/src/store.js
@@ -8,7 +8,9 @@ const rootReducer = combineReducers({
 
 const store = createStore(
   rootReducer,
-  window.devToolsExtension ? window.devToolsExtension() : f => f
+  window.__REDUX_DEVTOOLS_EXTENSION__
+    ? window.__REDUX_DEVTOOLS_EXTENSION__()
+    : f => f
 );
 
 export default store;


### PR DESCRIPTION
In [Redux DevTools Extension v2.7](https://github.com/zalmoxisus/redux-devtools-extension/releases/tag/v2.7.0) the `window.devToolsExtension` function has been renamed to `window.__REDUX_DEVTOOLS_EXTENSION__`.

This PR updates the reference.