### PR TITLE
Inject MAJI_APP_* environment variables by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Settings can be extended with default, env agnostic, settings. [#176](https://github.com/kabisa/maji/pull/176)
+- Environment variables starting with `MAJI_APP_` are injected by default. They can be referenced by `process.env.MAJI_APP_*` in your code. [#190](https://github.com/kabisa/maji/pull/190)
 
 ### Changed
 - Made cosmetic changes to the documentation.


### PR DESCRIPTION
With this PR, environment variables starting with `MAJI_APP_` are injected by default. They can be referenced by `process.env.MAJI_APP_*`.