### PR TITLE
Fix several issues related to relative paths when creating a new project

### DIFF
--- a/script/create-project
+++ b/script/create-project
@@ -12,6 +12,8 @@ MAJI_VERSION=${MAJI_VERSION:-$CURRENT_MAJI_VERSION}
 
 TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t maji)
 
+echo "Creating project in $APP_PATH ..."
+
 pushd "$MAJI_ROOT" >/dev/null 2>&1
   cp -R project_template/* "$TMP_DIR"
 
@@ -26,7 +28,7 @@ pushd "$MAJI_ROOT" >/dev/null 2>&1
 
     # npm strips .gitignore files during pack
     [ -f gitignore ] && (mv gitignore .gitignore || exit 0)
-    command -v git >/dev/null && git init || true
+    command -v git >/dev/null && git init >/dev/null || true
   popd >/dev/null 2>&1
 popd >/dev/null 2>&1
 

--- a/script/init.sh
+++ b/script/init.sh
@@ -17,10 +17,11 @@ done
 TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t maji)
 
 pushd "$TMP_DIR" >/dev/null 2>&1
-  yarn add --silent maji --no-lockfile --prod
-  ./node_modules/.bin/maji new "$APP_PACKAGE" "$APP_PATH"
-  RESULT=$?
+  yarn add --silent ${MAJI_MODULE:-maji} --no-lockfile --prod
 popd >/dev/null 2>&1
+
+"$TMP_DIR"/node_modules/.bin/maji new "$APP_PACKAGE" "$APP_PATH"
+RESULT=$?
 
 rm -r $TMP_DIR
 exit $RESULT

--- a/src/cli.js
+++ b/src/cli.js
@@ -54,7 +54,7 @@ program
   .on("--help", () =>
     console.log("  Example:\n  maji new org.example.my-app ~/Code/my-app")
   )
-  .action(function(packageName, path) {
+  .action(function(packageName, projectPath) {
     if (!packageName.match(/.*\..*\..*/)) {
       console.log(
         "Please specify a valid package name, for example org.example.my-app"
@@ -62,7 +62,8 @@ program
       process.exit(1);
     }
 
-    return runScript("create-project", [packageName, path]);
+    projectPath = path.resolve(projectPath);
+    return runScript("create-project", [packageName, projectPath]);
   });
 
 program


### PR DESCRIPTION
* CLI now resolves relative paths into absolute paths

* This still didn't cut it for projects created with the init script,
since the init script called the Maji CLI from a temp directory. This
isn't nessecary, so the init script now invokes the Maji CLI from the
original PWD where the init script was ran.

* Last, some additional logging was added and output of `git init` is
supressed to remove some noise.