### PR TITLE
Work around NPM removing .gitignore from published packages

### DIFF
--- a/project_template/.gitignore
+++ b/project_template/.gitignore
@@ -1,15 +1,1 @@
-.vscode
-.idea
-*.iml
-node_modules
-.DS_Store
-*.log
-dist
-.env
-reports/
-
-# cordova stuff
-cordova/platforms/*
-cordova/plugins/*
-!cordova/platforms/.keep
-!cordova/plugins/.keep
+gitignore

--- a/project_template/gitignore
+++ b/project_template/gitignore
@@ -1,0 +1,15 @@
+.vscode
+.idea
+*.iml
+node_modules
+.DS_Store
+*.log
+dist
+.env
+reports/
+
+# cordova stuff
+cordova/platforms/*
+cordova/plugins/*
+!cordova/platforms/.keep
+!cordova/plugins/.keep

--- a/script/create-project
+++ b/script/create-project
@@ -24,8 +24,8 @@ pushd "$MAJI_ROOT" >/dev/null 2>&1
     (cd cordova/ && ln -s ../dist www)
     (cd bin/ && ln -s ../node_modules/.bin/maji .)
 
-    # npm renames .gitignore to .npmignore
-    [ -f .npmignore ] && (mv .npmignore .gitignore || exit 0)
+    # npm strips .gitignore files during pack
+    [ -f gitignore ] && (mv gitignore .gitignore || exit 0)
     command -v git >/dev/null && git init || true
   popd >/dev/null 2>&1
 popd >/dev/null 2>&1


### PR DESCRIPTION
See https://github.com/npm/npm/issues/3763 for details.
Proposed fix of including an empty .npmignore doesn't work.

This commit fixes the issue by renaming the `.gitignore` to `gitignore`.
During project creation we rename it back to `.gitignore`.
For the gitignore to work inside the Maji src repo,
a symlink from `gitignore` -> `.gitignore` is added.

Fixes #179.