### PR TITLE
Prevent dist directory itself to be removed by webpack

### DIFF
--- a/project_template/webpack.config.js
+++ b/project_template/webpack.config.js
@@ -35,7 +35,7 @@ const plugins = [
     inject: false,
     minify: false
   }),
-  new Clean(["dist"]),
+  new Clean(["dist"], { verbose: false, exclude: [".gitkeep"] }),
   new webpack.optimize.CommonsChunkPlugin({
     name: "vendor"
   }),


### PR DESCRIPTION
If this happens, Cordova starts complaining. See #181 for details.