### PR TITLE
Add script to publish beta packages from CI

### DIFF
--- a/bin/publish-beta
+++ b/bin/publish-beta
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Note that this script assumes that `npm add-user` has been run prior to running this script.
+set -e
+ORIGINAL_VERSION=$(node -e 'console.log(require("./package.json").version)')
+
+restore_original_version() {
+  npm_config_git_tag_version=false npm version "$ORIGINAL_VERSION"
+}
+trap restore_original_version EXIT
+
+VERSION="$ORIGINAL_VERSION-$(git rev-parse --short HEAD)"
+npm_config_git_tag_version=false npm version "$VERSION"
+npm publish --tag beta

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maji",
-  "version": "3.0.2",
+  "version": "3.1.0-beta",
   "license": "MIT",
   "module": "lib/bundle.js",
   "bin": {


### PR DESCRIPTION
Packages are tagged with the current git commit, since NPM does not allow
uploading a package with the same version twice.

Note that this script uses npm to publish, since yarn is a little more
difficult to automate. For example it doesn't allow to prevent the new
package.json to be committed.