### PR TITLE
Ignore css-appearance when linting

### DIFF
--- a/project_template/.stylelintrc.js
+++ b/project_template/.stylelintrc.js
@@ -16,7 +16,7 @@ module.exports = {
       {
         browsers: supportedBrowsers,
         severity: "warning",
-        ignore: ["font-unicode-range", "css-resize"]
+        ignore: ["font-unicode-range", "css-resize", "css-appearance"]
       }
     ]
   }


### PR DESCRIPTION
Since CSS Appearance is often used to "reset" the browsers default rendering of form controls, it is useful to ignore it as an unsupported feature.