### PR TITLE
Remove history keeping

### DIFF
--- a/project_template/src/components/Header.js
+++ b/project_template/src/components/Header.js
@@ -1,14 +1,14 @@
 import { h } from "preact";
 import Icon from "./Icon";
 import styles from "./Header.scss";
-import { goBack } from "src/support/history";
+import { history } from "src/support/history";
 
 export const BackButton = ({ href }) => {
   const onClick = function(e) {
     e.preventDefault();
     e.stopImmediatePropagation();
 
-    goBack(href);
+    history.goBack();
   };
 
   return (

--- a/project_template/src/support/history.js
+++ b/project_template/src/support/history.js
@@ -1,13 +1,3 @@
 import createHistory from "history/createHashHistory";
 
-let previous = null;
 export const history = createHistory();
-
-history.listen(function(location, action) {
-  previous = action === "PUSH" ? location : null;
-});
-
-export function goBack(location) {
-  if (previous) history.goBack();
-  else history.replace(location);
-}


### PR DESCRIPTION
The project template implements a history listener that keeps track of the previous page. The previous page is then used in the `goBack` function.

However, using this `goBack` function prevents the user from going back more than one page. Therefore I propose to use `history.goBack` instead.

If necessary, I can change the `BackButton` from an `a` to a `button` as well. That would remove the need for the `href` prop but will probably need some styling.