### PR TITLE
Show diff in Mocha reports

### DIFF
--- a/project_template/config/karma.js
+++ b/project_template/config/karma.js
@@ -28,6 +28,9 @@ module.exports = function(config) {
         reporter: "html"
       }
     },
+    mochaReporter: {
+      showDiff: true
+    },
     port: 9876,
     listenAddress: "localhost",
     hostname: "localhost",


### PR DESCRIPTION
For the project I'm working on, I've configured karma such that diffs are shown in the reports generated by Mocha when equality assertions fail. The feature is documented here: https://github.com/litixsoft/karma-mocha-reporter#showdiff

It seems like pretty useful behavior to me, so I propose to make it the default behavior.