### PR TITLE
Use SERVER_PORT environment variable instead of PORT

### DIFF
--- a/project_template/config/nightwatch.js
+++ b/project_template/config/nightwatch.js
@@ -16,7 +16,7 @@ module.exports = {
   },
   test_settings: {
     default: {
-      launch_url: `http://localhost:${process.env.PORT || 9091}/`,
+      launch_url: `http://localhost:${process.env.SERVER_PORT || 9091}/`,
       selenium_port: 4444,
       selenium_host: "localhost",
       desiredCapabilities: {


### PR DESCRIPTION
I have the feeling that process.env.PORT wasn't used intentionally here, but I could be wrong.