### PR TITLE
Allow all external communication in Cordova by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Environment variables starting with `MAJI_APP_` are injected by default. They can be referenced by `process.env.MAJI_APP_*` in your code. [#190](https://github.com/kabisa/maji/pull/190)
+- Allow all external communication in Cordova by default. [#216](https://github.com/kabisa/maji/pull/216)
 
 ### Changed
 - Nightwatch tests now run headless by default. [#200](https://github.com/kabisa/maji/pull/200)

--- a/project_template/cordova/config.xml
+++ b/project_template/cordova/config.xml
@@ -27,6 +27,9 @@
     <!-- disable icloud storage sync -->
     <preference name="BackupWebStorage" value="local"/>
 
+    <!-- allow all external communication by default -->
+    <allow-navigation href="*" />
+
     <plugin name="cordova-plugin-networkactivityindicator" spec="~0.1.1" />
     <plugin name="cordova-plugin-splashscreen" spec="~4.0.0"/>
     <plugin name="cordova-plugin-whitelist" spec="~1.3.0"/>


### PR DESCRIPTION
This is a sensible default and can be modified by projects as they see
fit.

Closes #208.