### PR TITLE
Upgrade cordova platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Nightwatch tests now run headless by default. [#200](https://github.com/kabisa/maji/pull/200)
+- Upgraded Cordova platforms. [#217](https://github.com/kabisa/maji/pull/217)
 
 ## 3.1.1
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@
 
 ## Browser support
 
-Maji will work in evergreen browsers, IE10+, Android 4.4+ and iOS 8+. Minimal horizontal resolution is 320px.
+Maji will work in evergreen browsers, IE10+, Android 5.0+ and iOS 8+. Minimal horizontal resolution is 320px.
 
 Minimal support can be determined by which technologies Maji uses, and which front-end technologies you decide to use:
 
@@ -69,19 +69,19 @@ Preact:
 Flexbox:
 
 * IE10+
-* Android 4.4+ (2.1 - 4.3 if you don't use `flex-wrap`)
+* Android 5.0+ (2.1 - 4.3 if you don't use `flex-wrap`)
 * iOS 7.1+ (3.2 - 6.1 if you don't use `flex-wrap`)
 
 CSS calc:
 
 * IE9+
 * iOS 6.1+
-* Android 4.4+
+* Android 5.0+
 
 SVG:
 
 * IE9+
-* Android 4.4+ (3+ if you don't use masking)
+* Android 5.0+ (3+ if you don't use masking)
 * iOS 3.2+
 
 ## Components you might not need

--- a/project_template/cordova/config.xml
+++ b/project_template/cordova/config.xml
@@ -7,8 +7,8 @@
 
     <hook type="before_platform_add" src="../node_modules/maji/cordova/hooks/before_platform_add.js" />
 
-    <engine name="android" spec="~6.2.3" />
-    <engine name="ios" spec="~4.4.0" />
+    <engine name="android" spec="^7.0.0" />
+    <engine name="ios" spec="^4.5.4" />
 
     <preference name="DisallowOverscroll" value="true"/>
     <preference name="Orientation" value="portrait" />
@@ -21,8 +21,8 @@
     <preference name="SplashScreenDelay" value="0" />
 
     <!-- target Android SDK versions //-->
-    <preference name="android-minSdkVersion" value="14" />
-    <preference name="android-targetSdkVersion" value="19" />
+    <preference name="android-minSdkVersion" value="21" />
+    <preference name="android-targetSdkVersion" value="24" />
 
     <!-- disable icloud storage sync -->
     <preference name="BackupWebStorage" value="local"/>

--- a/project_template/cordova/package.json
+++ b/project_template/cordova/package.json
@@ -14,8 +14,8 @@
         }
     },
     "dependencies": {
-        "cordova-android": "~6.2.3",
-        "cordova-ios": "~4.4.0",
+        "cordova-android": "^7.0.0",
+        "cordova-ios": "^4.5.4",
         "cordova-plugin-networkactivityindicator": "~0.1.1",
         "cordova-plugin-splashscreen": "~4.0.0",
         "cordova-plugin-whitelist": "~1.3.0"


### PR DESCRIPTION
This PR upgrades both `cordova-android` and `cordova-ios` to the latest versions.

Also up the Android minSdkVersion to 21 (Android 5.0).

Fixes #182, as that issue was fixed in `cordova-ios` 4.5.