### PR TITLE
Fix running nonHeadless e2e tests against latest chromedriver

### DIFF
--- a/project_template/config/nightwatch.js
+++ b/project_template/config/nightwatch.js
@@ -33,7 +33,7 @@ module.exports = {
       desiredCapabilities: {
         browserName: "chrome",
         chromeOptions: {
-          args: null
+          args: ["--default"]
         }
       }
     },


### PR DESCRIPTION
Can't pass null args. Must pass *some* args in order
to have nightwatch overwrite defaults.

Fixes #225 