### PR TITLE
Fix/hot reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Updated ChromeDriver wrapper [#220](https://github.com/kabisa/maji/pull/220)
+- Live reload is now standard on when using `bin/maji start`
+
+### Fixed
+- Disabling livereload will no longer produce console errors
 
 ## [3.2.2]
 

--- a/project_template/webpack.config.js
+++ b/project_template/webpack.config.js
@@ -5,6 +5,7 @@ const uglify = require("./config/uglify");
 
 const env = process.env.NODE_ENV || "development";
 const isProd = env === "production";
+const hotReload = process.env.LIVERELOAD === "true";
 const out = path.resolve(__dirname, "dist");
 const exclusions = /node_modules/;
 
@@ -40,9 +41,13 @@ if (isProd) {
     new webpack.optimize.UglifyJsPlugin(uglify)
   );
 } else {
+  if (hotReload) {
+    plugins.push(
+      // enable HMR globally
+      new webpack.HotModuleReplacementPlugin()
+    );
+  }
   plugins.push(
-    // enable HMR globally
-    new webpack.HotModuleReplacementPlugin(),
     // prints more readable module names in the browser console on HMR updates
     new webpack.NamedModulesPlugin(),
     // prevent emitting assets with errors
@@ -53,9 +58,10 @@ if (isProd) {
 
 // optionally live-reloadable entry points
 const entryPoints = function() {
-  const items = isProd
-    ? []
-    : ["webpack-hot-middleware/client?noInfo=true&reload=true"];
+  const items =
+    isProd || !hotReload
+      ? []
+      : ["webpack-hot-middleware/client?noInfo=true&reload=true"];
   items.push(...arguments);
   return items;
 };

--- a/project_template/webpack.config.js
+++ b/project_template/webpack.config.js
@@ -5,7 +5,7 @@ const uglify = require("./config/uglify");
 
 const env = process.env.NODE_ENV || "development";
 const isProd = env === "production";
-const hotReload = process.env.LIVERELOAD === "true";
+const hotReload = (process.env.LIVERELOAD === "true") && !isProd;
 const out = path.resolve(__dirname, "dist");
 const exclusions = /node_modules/;
 
@@ -59,9 +59,9 @@ if (isProd) {
 // optionally live-reloadable entry points
 const entryPoints = function() {
   const items =
-    isProd || !hotReload
-      ? []
-      : ["webpack-hot-middleware/client?noInfo=true&reload=true"];
+    hotReload
+      ? ["webpack-hot-middleware/client?noInfo=true&reload=true"];
+      : []
   items.push(...arguments);
   return items;
 };

--- a/project_template/webpack.config.js
+++ b/project_template/webpack.config.js
@@ -5,7 +5,7 @@ const uglify = require("./config/uglify");
 
 const env = process.env.NODE_ENV || "development";
 const isProd = env === "production";
-const hotReload = (process.env.LIVERELOAD === "true") && !isProd;
+const hotReload = process.env.LIVERELOAD === "true" && !isProd;
 const out = path.resolve(__dirname, "dist");
 const exclusions = /node_modules/;
 
@@ -58,10 +58,9 @@ if (isProd) {
 
 // optionally live-reloadable entry points
 const entryPoints = function() {
-  const items =
-    hotReload
-      ? ["webpack-hot-middleware/client?noInfo=true&reload=true"]
-      : [];
+  const items = hotReload
+    ? ["webpack-hot-middleware/client?noInfo=true&reload=true"]
+    : [];
   items.push(...arguments);
   return items;
 };

--- a/project_template/webpack.config.js
+++ b/project_template/webpack.config.js
@@ -60,8 +60,8 @@ if (isProd) {
 const entryPoints = function() {
   const items =
     hotReload
-      ? ["webpack-hot-middleware/client?noInfo=true&reload=true"];
-      : []
+      ? ["webpack-hot-middleware/client?noInfo=true&reload=true"]
+      : [];
   items.push(...arguments);
   return items;
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -91,9 +91,9 @@ program
   .option("-p --port [port]", "Port to listen on [9090]", parsePort, 9090)
   .option(
     "-l --livereload [flag]",
-    "Enable livereload [false]",
+    "Enable livereload [true]",
     parseBoolean,
-    false
+    true
   )
   .action(options => {
     const env = {


### PR DESCRIPTION
Hot reload was on by default when using `yarn start`
it was default off for `bin/maji start`

I changed it that `bin/maji start` will now also have livereload on.

you can still turn it off by running `bin/maji start -l false`

also, having live reload off produced errors in the console:

```
GET http://localhost:9090/__webpack_hmr 404 (Not Found)
```

This has also been fixed.