### PR TITLE
Disable inclusion of cordova in development mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Updated ChromeDriver wrapper [#220](https://github.com/kabisa/maji/pull/220)
 
+### Fixed
+- Only include `cordova.js` if a cordova build is needed
+
 ## [3.2.2]
 
 ### Fixed

--- a/project_template/package.json
+++ b/project_template/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "build": "NODE_ENV=${NODE_ENV:-production} webpack",
-    "start": "LIVERELOAD=${LIVERELOAD:-true} USE_CORDOVA=${USE_CORDOVA:-false} script/dev-server.js",
+    "start": "LIVERELOAD=${LIVERELOAD:-true} script/dev-server.js",
     "test": "NODE_ENV=${NODE_ENV:-test} bin/ci",
     "test:unit": "NODE_ENV=${NODE_ENV:-test} karma start config/karma.js --single-run",
     "test:watch": "NODE_ENV=${NODE_ENV:-test} karma start config/karma.js --watch",

--- a/project_template/package.json
+++ b/project_template/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "build": "NODE_ENV=${NODE_ENV:-production} webpack",
-    "start": "LIVERELOAD=${LIVERELOAD:-true} script/dev-server.js",
+    "start": "LIVERELOAD=${LIVERELOAD:-true} USE_CORDOVA=${USE_CORDOVA:-false} script/dev-server.js",
     "test": "NODE_ENV=${NODE_ENV:-test} bin/ci",
     "test:unit": "NODE_ENV=${NODE_ENV:-test} karma start config/karma.js --single-run",
     "test:watch": "NODE_ENV=${NODE_ENV:-test} karma start config/karma.js --watch",

--- a/project_template/src/index.html
+++ b/project_template/src/index.html
@@ -10,7 +10,9 @@
     <meta name="apple-mobile-web-app-title" content="<$= appName $>">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 
+<% if (htmlWebpackPlugin.options.useCordova) { %>
     <script src="cordova.js"></script>
+<% } %>
     <script type="text/javascript">
       if(window.navigator.standalone) {
         document.querySelector('html').className = 'ios-standalone';

--- a/project_template/webpack.config.js
+++ b/project_template/webpack.config.js
@@ -4,6 +4,7 @@ const babel = require("./config/babel");
 const uglify = require("./config/uglify");
 
 const env = process.env.NODE_ENV || "development";
+const useCordova = (process.env.USE_CORDOVA || "true") === "true";
 const isProd = env === "production";
 const out = path.resolve(__dirname, "dist");
 const exclusions = /node_modules/;
@@ -22,7 +23,7 @@ const plugins = [
   ...require("maji/lib/webpack").plugins,
   new HTML({
     template: "src/index.html",
-    useCordova: env !== "development",
+    useCordova,
     inject: false,
     minify: false
   }),

--- a/project_template/webpack.config.js
+++ b/project_template/webpack.config.js
@@ -4,7 +4,7 @@ const babel = require("./config/babel");
 const uglify = require("./config/uglify");
 
 const env = process.env.NODE_ENV || "development";
-const useCordova = (process.env.USE_CORDOVA || "true") === "true";
+const useCordova = (process.env.USE_CORDOVA || "false") === "true";
 const isProd = env === "production";
 const out = path.resolve(__dirname, "dist");
 const exclusions = /node_modules/;

--- a/project_template/webpack.config.js
+++ b/project_template/webpack.config.js
@@ -22,6 +22,7 @@ const plugins = [
   ...require("maji/lib/webpack").plugins,
   new HTML({
     template: "src/index.html",
+    useCordova: env !== "development",
     inject: false,
     minify: false
   }),

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -12,7 +12,8 @@ const { runYarn, runCordova } = require("./utils");
  */
 module.exports.build = (environment, platform, mode) => {
   const env = {
-    NODE_ENV: environment
+    NODE_ENV: environment,
+    USE_CORDOVA: !!platform
   };
 
   const buildAssets = () => runYarn(["run", "build"], env);
@@ -32,7 +33,8 @@ module.exports.build = (environment, platform, mode) => {
  */
 module.exports.run = (environment, platform, deviceType, restArgs) => {
   const env = {
-    NODE_ENV: environment
+    NODE_ENV: environment,
+    USE_CORDOVA: true
   };
   const deviceOpts = process.env.DEVICE_OPTS ? [process.env.DEVICE_OPTS] : [];
 


### PR DESCRIPTION
When developing locally, you always get a 404 on cordova.js

This PR disables the inclusion of cordova for development builds.

In the future we could extend this that even in the build process we could omit cordova for building web frontends. (using an env var for instance)