### PR TITLE
Don't enable Redux devtools support in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Disable Redux Devtools extension support in production by default [#230](https://github.com/kabisa/maji/pull/230)
+
 ## [3.3.0]
 
 ### Changed

--- a/project_template/src/store.js
+++ b/project_template/src/store.js
@@ -6,11 +6,12 @@ const rootReducer = combineReducers({
   // additional reducers would be added here
 });
 
-const store = createStore(
-  rootReducer,
-  window.__REDUX_DEVTOOLS_EXTENSION__
-    ? window.__REDUX_DEVTOOLS_EXTENSION__()
-    : f => f
-);
+const devtools = () =>
+  (process.env.NODE_ENV !== "production" &&
+    window.__REDUX_DEVTOOLS_EXTENSION__ &&
+    window.__REDUX_DEVTOOLS_EXTENSION__()) ||
+  (f => f);
+
+const store = createStore(rootReducer, devtools());
 
 export default store;


### PR DESCRIPTION
Enabling Redux devtools support in production does not make sense,
and provides insight/hooks into your app that you likely don't want.