### PR TITLE
Bump node version used in project template

### DIFF
--- a/project_template/Dockerfile
+++ b/project_template/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7
+FROM node:8
 
 RUN apt-get update \
   && apt-get -y install apt-utils \

--- a/project_template/package.json
+++ b/project_template/package.json
@@ -86,5 +86,8 @@
     "webpack-dev-server": "^2.4.5",
     "webpack-hot-middleware": "^2.18.0",
     "yaml-loader": "^0.4.0"
+  },
+  "engines": {
+    "version": ">=8"
   }
 }


### PR DESCRIPTION
So it matches the required engine version in the upstream Maji dependency, avoiding: `incompatible module` errors.