### PR TITLE
fixes js styling in WelcomePage.js

### DIFF
--- a/project_template/src/modules/welcome/containers/WelcomePage.js
+++ b/project_template/src/modules/welcome/containers/WelcomePage.js
@@ -48,4 +48,7 @@ const mapDispatchToProps = dispatch => ({
   onDecrement: () => dispatch({ type: actions.COUNTER_DECREMENT })
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(WelcomePage);
+export default connect(
+  mapStateToProps, 
+  mapDispatchToProps
+)(WelcomePage);


### PR DESCRIPTION
**How to reproduce**

 1. Create new Maji app with `yarn create maji-app`
 2. Run `bin/maji test`

**What happens?**

```
src/modules/welcome/containers/WelcomePage.js
  51:24  error  Replace `mapStateToProps,·mapDispatchToProps` with `⏎··mapStateToProps,⏎··mapDispatchToProps⏎`  prettier/prettier

✖ 1 problem (1 error, 0 warnings)
```

**What did you expect to happen instead?**

```
OK. 7  total assertions passed.
```

This PR updates `WelcomePage.js` for stylelint compliance. This makes a newly generated project pass all tests out of the box. 