### PR TITLE
Exclude project template from Prettier check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules/
+lib/
+project_template/
+packages/create-maji-app/templates/

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "NODE_ENV=${NODE_ENV:-production} rollup -c",
     "dev": "NODE_ENV=${NODE_ENV:-development} rollup -c -w",
     "start": "cd project_template; yarn start",
-    "prettier": "prettier '{,!(node_modules|lib)/**/}*.js'",
+    "prettier": "prettier '**/*.js'",
     "prepare": "yarn run --silent build",
     "test": "NODE_ENV=${NODE_ENV:-test} bin/ci",
     "test:unit": "NODE_ENV=${NODE_ENV:-test} karma start --singleRun",


### PR DESCRIPTION
The generated project can have a different version of Prettier than Maji
itself. Besides, the formatting of the project template itself is
already checked in CI using the exact Prettier version used by a new
app.

See https://github.com/kabisa/maji/pull/237 for details.