### PR TITLE
Don't clear app mount point

### DIFF
--- a/project_template/src/index.js
+++ b/project_template/src/index.js
@@ -9,7 +9,6 @@ const renderApp = function() {
   const App = require("./containers/App").default;
   const root = document.querySelector("#maji-app");
 
-  root.innerHTML = "";
   render(
     <Provider store={store}>
       <App />


### PR DESCRIPTION
This was added back at a time when we were trying to
mimic React, which does this (while preact appends).
However back then we were not attaching directly to
the `<body  />`. Now that we are, this doesn't make
sense any more, as it removes from the DOM other tags
that are added to the body.