### PR TITLE
Pass literal arguments to `cordova build`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - bin/setup uses not-yet installed dependency [#231](https://github.com/kabisa/maji/pull/231)
+- Literal arguments not passed to `cordova build` ([#252](https://github.com/kabisa/maji/pull/252))
 
 ## [3.3.0]
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -61,7 +61,7 @@ program
       options.environment || process.env.NODE_ENV || "production";
     const mode = options.release ? "release" : "debug";
 
-    tasks.build(environment, platform, mode).catch(exit);
+    tasks.build(environment, platform, mode, literalArgs()).catch(exit);
   });
 
 program

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -10,7 +10,7 @@ const { runYarn, runCordova } = require("./utils");
  *
  * @returns Promise - resolves when build succeeds, rejects if build fails.
  */
-module.exports.build = (environment, platform, mode) => {
+module.exports.build = (environment, platform, mode, restArgs) => {
   const env = {
     NODE_ENV: environment,
     USE_CORDOVA: !!platform
@@ -18,7 +18,9 @@ module.exports.build = (environment, platform, mode) => {
 
   const buildAssets = () => runYarn(["run", "build"], env);
   const buildNative = () =>
-    platform ? buildCordovaApp(platform, mode, env) : Promise.resolve();
+    platform
+      ? buildCordovaApp(platform, mode, env, restArgs)
+      : Promise.resolve();
 
   return buildAssets().then(buildNative);
 };
@@ -48,9 +50,10 @@ module.exports.run = (environment, platform, deviceType, restArgs) => {
   return buildAssets().then(cordovaRun);
 };
 
-const buildCordovaApp = (platform, mode, env) => {
+const buildCordovaApp = (platform, mode, env, restArgs) => {
   const prepareCordova = () => runCordova(["prepare", platform], env);
-  const buildCordova = () => runCordova(["build", platform, `--${mode}`], env);
+  const buildCordova = () =>
+    runCordova(["build", platform, `--${mode}`, ...restArgs], env);
 
   return prepareCordova().then(buildCordova);
 };


### PR DESCRIPTION
This PR fixes literal arguments on `bin/maji build` that were not passed on to `cordova build`. This was quite unfortunate, as it meant that arguments like `bin/maji build -- --codeSignIdentity` etc were not passed on to Cordova.