### PR TITLE
Remove obsolete setup for browserslist

### DIFF
--- a/project_template/.stylelintrc.js
+++ b/project_template/.stylelintrc.js
@@ -1,5 +1,3 @@
-const supportedBrowsers = require("./config/supported-browsers");
-
 module.exports = {
   extends: "stylelint-config-standard",
   plugins: ["stylelint-no-unsupported-browser-features"],
@@ -14,7 +12,6 @@ module.exports = {
     "plugin/no-unsupported-browser-features": [
       true,
       {
-        browsers: supportedBrowsers,
         severity: "warning",
         ignore: ["font-unicode-range", "css-resize", "css-appearance"]
       }

--- a/project_template/config/babel.js
+++ b/project_template/config/babel.js
@@ -1,13 +1,8 @@
-const supportedBrowsers = require("./supported-browsers");
-
 module.exports = {
   presets: [
     [
       "@babel/env",
       {
-        targets: {
-          browsers: supportedBrowsers
-        },
         modules: false,
         loose: true,
         useBuiltIns: "entry"

--- a/project_template/config/supported-browsers.js
+++ b/project_template/config/supported-browsers.js
@@ -1,4 +1,0 @@
-const path = require("path");
-module.exports = require("browserslist").readConfig(
-  path.join(__dirname, "../browserslist")
-).defaults;


### PR DESCRIPTION
As described in #262 we can remove the setup for browserslist since this is now supported out of the box.