### PR TITLE
Make shelljs a “runtime” dependency

### DIFF
--- a/cordova/hooks/before_platform_add.js
+++ b/cordova/hooks/before_platform_add.js
@@ -1,4 +1,4 @@
-require("shelljs/global");
+const shell = require("shelljs");
 const path = require("path");
 
 function ensureDependencyInstalled(projectRoot, mod) {
@@ -14,7 +14,7 @@ function ensureDependencyInstalled(projectRoot, mod) {
   } catch (e) {
     console.log(`Installing ${mod}`);
     return new Promise(function(resolve, reject) {
-      exec(`npm install ${mod}`, function(exitCode) {
+      shell.exec(`npm install ${mod}`, function(exitCode) {
         if (exitCode == 0) resolve();
         else reject(e);
       });

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "rollup-plugin-commonjs": "^9.0.0",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-replace": "^2.1.0",
-    "shelljs": "^0.8.3",
     "webpack": "^4.5.0"
   },
   "dependencies": {
@@ -53,7 +52,8 @@
     "cross-spawn": "^5.1.0",
     "git-revision-webpack-plugin": "^2.5.1",
     "i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc8.tar.gz",
-    "opn": "^5.3.0"
+    "opn": "^5.3.0",
+    "shelljs": "^0.8.3"
   },
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
It needs to be available transitively to peers,
as they will execute the cordova hook which needs 
the dependency.
Lack of transitivity went unnoticed at first due
to the local use of “linked” dependencies.